### PR TITLE
New booking email notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the code for Naisten Linja's services including:
 
 - [x] User authentication via Discourse SSO
-- [ ] Volunteer bookings management
+- [x] Volunteer bookings management
 - [x] Online letter API
 - [x] Admin interface for staff and volunteer to answer to online letters
 

--- a/db/migrations/20220313065738-add-booking-notification-setting-to-users-table.js
+++ b/db/migrations/20220313065738-add-booking-notification-setting-to-users-table.js
@@ -1,0 +1,39 @@
+'use strict';
+const async = require('async');
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  async.series(
+    [
+      db.addColumn.bind(db, 'users', 'new_booking_notification_days_threshold', {
+        type: 'int',
+        notNull: false,
+        defaultValue: 7,
+      }),
+    ],
+    callback,
+  );
+};
+
+exports.down = function (db) {
+  // Deleting all 'iv' values for existing letters and replies would
+  // make them impossible to decrypt. So this step should not be rolled back.
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/db/migrations/20220313065738-add-booking-notification-setting-to-users-table.js
+++ b/db/migrations/20220313065738-add-booking-notification-setting-to-users-table.js
@@ -21,7 +21,7 @@ exports.up = function (db, callback) {
       db.addColumn.bind(db, 'users', 'new_booking_notification_days_threshold', {
         type: 'int',
         notNull: false,
-        defaultValue: 7,
+        defaultValue: null,
       }),
     ],
     callback,

--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -11,6 +11,7 @@ import connectRedis, { RedisStore } from 'connect-redis';
 
 import authRoutes from './routes/authRoutes';
 import userRoutes from './routes/userRoutes';
+import profileRoutes from './routes/profileRoutes';
 import onlineLetterRoutes from './routes/onlineLetterRoutes';
 import letterRoutes from './routes/letterRoutes';
 import bookingTypesRoutes from './routes/bookingTypesRoutes';
@@ -137,6 +138,7 @@ export function createApp() {
   );
 
   app.use('/api/auth', authRoutes);
+  app.use('/api/profile', profileRoutes);
   app.use('/api/users', userRoutes);
   app.use('/api/online-letter', onlineLetterRoutes);
   app.use('/api/letters', letterRoutes);

--- a/src/backend/controllers/emailControllers.ts
+++ b/src/backend/controllers/emailControllers.ts
@@ -112,7 +112,7 @@ export async function sendNewBookingNotificationToStaffs(booking: ApiBooking) {
 
   const { startDay, startTime, endTime } = getBookingTimeComponents(booking);
   const text = `
-A new booking was made by user ${booking.fullName} (${booking.user.email}) with the follow details:
+A new booking was made for user ${booking.fullName} (${booking.user.email}) with the follow details:
 
 Booking: ${booking.bookingType.name}
 Date: ${startDay}
@@ -127,7 +127,7 @@ ${booking.bookingNote ? 'Booking note:\n' + booking.bookingNote : ''}
     to: staffEmails,
     subject: `New reservation made for slot ${startTime} - ${endTime} on ${startDay} for ${booking.bookingType.name}`,
     from: {
-      name: 'Naisten Linja Booking Notifcation',
+      name: 'New Booking Notifcation',
       email: sendGridFromEmailAddress,
     },
     text,

--- a/src/backend/controllers/userControllers.ts
+++ b/src/backend/controllers/userControllers.ts
@@ -1,8 +1,8 @@
-import { ApiUserData } from '../../common/constants-common';
-import { User, getUsers, getUserByUuid, updateUserRole } from '../models/users';
+import { ApiUserData, ApiUpdateUserSettingsParams } from '../../common/constants-common';
+import * as userModel from '../models/users';
 
 export async function getApiUsers(): Promise<Array<ApiUserData>> {
-  const dbUsers = await getUsers();
+  const dbUsers = await userModel.getUsers();
   if (!dbUsers) {
     return [];
   }
@@ -22,16 +22,29 @@ export async function updateApiUserRole({
   uuid,
   role,
 }: {
-  uuid: User['uuid'];
-  role: User['role'];
-}): Promise<User | null> {
-  const user = await getUserByUuid(uuid);
+  uuid: userModel.User['uuid'];
+  role: userModel.User['role'];
+}): Promise<userModel.User | null> {
+  const user = await userModel.getUserByUuid(uuid);
   if (!user) {
     return null;
   }
-  const result = await updateUserRole({ uuid, role });
+  const result = await userModel.updateUserRole({ uuid, role });
   if (result) {
     return result;
   }
   return null;
+}
+
+export async function updateUserSettings({
+  uuid,
+  newBookingNotificationDaysThreshold,
+}: ApiUpdateUserSettingsParams & {
+  uuid: string;
+}): Promise<userModel.User | null> {
+  const result = await userModel.updateUserSettings({ uuid, newBookingNotificationDaysThreshold });
+  if (!result) {
+    return null;
+  }
+  return result;
 }

--- a/src/backend/controllers/userControllers.ts
+++ b/src/backend/controllers/userControllers.ts
@@ -13,6 +13,7 @@ export async function getApiUsers(): Promise<Array<ApiUserData>> {
       fullName: user.fullName,
       created: user.created,
       role: user.role,
+      newBookingNotificationDaysThreshold: user.newBookingNotificationDaysThreshold,
     };
   });
   return users;
@@ -42,9 +43,31 @@ export async function updateUserSettings({
 }: ApiUpdateUserSettingsParams & {
   uuid: string;
 }): Promise<userModel.User | null> {
-  const result = await userModel.updateUserSettings({ uuid, newBookingNotificationDaysThreshold });
+  const threshold =
+    newBookingNotificationDaysThreshold && newBookingNotificationDaysThreshold > 0
+      ? newBookingNotificationDaysThreshold
+      : null;
+  const result = await userModel.updateUserSettings({
+    uuid,
+    newBookingNotificationDaysThreshold: threshold,
+  });
   if (!result) {
     return null;
   }
   return result;
+}
+
+export async function getUserData(uuid: string): Promise<ApiUserData | null> {
+  const user = await userModel.getUserByUuid(uuid);
+  if (!user) {
+    return null;
+  }
+  return {
+    uuid: user.uuid,
+    email: user.email,
+    fullName: user.fullName,
+    created: user.created,
+    role: user.role,
+    newBookingNotificationDaysThreshold: user.newBookingNotificationDaysThreshold,
+  };
 }

--- a/src/backend/models/users.ts
+++ b/src/backend/models/users.ts
@@ -1,5 +1,5 @@
 import db from '../db';
-import { UserRole } from '../../common/constants-common';
+import { UserRole, ApiUpdateUserSettingsParams } from '../../common/constants-common';
 
 export interface User {
   id: number;
@@ -121,6 +121,32 @@ export async function updateUserRole({
     return queryResultToUser(result.rows[0]);
   } catch (err) {
     console.error(`User ${uuid} not found`);
+    console.error(err);
+    return null;
+  }
+}
+
+export async function updateUserSettings({
+  uuid,
+  newBookingNotificationDaysThreshold = null,
+}: ApiUpdateUserSettingsParams & {
+  uuid: string;
+}): Promise<User | null> {
+  try {
+    const queryText = `
+      UPDATE users
+      SET new_booking_notification_days_threshold = $2::int
+      WHERE uuid = $1::text
+      RETURNING *;
+    `;
+    const queryValues = [uuid, newBookingNotificationDaysThreshold];
+    const result = await db.query<UserQueryResult>(queryText, queryValues);
+    if (result.rows.length < 1) {
+      return null;
+    }
+    return queryResultToUser(result.rows[0]);
+  } catch (err) {
+    console.error(`Unable to update settings of user ${uuid}`);
     console.error(err);
     return null;
   }

--- a/src/backend/models/users.ts
+++ b/src/backend/models/users.ts
@@ -9,6 +9,7 @@ export interface User {
   fullName: string | null;
   email: string;
   discourseUserId: number;
+  newBookingNotificationDaysThreshold: number | null;
 }
 
 export interface UserQueryResult {
@@ -19,6 +20,7 @@ export interface UserQueryResult {
   full_name?: string;
   email: string;
   discourse_user_id: number;
+  new_booking_notification_days_threshold: number | null;
 }
 
 export type UpsertUserParams = {
@@ -36,6 +38,7 @@ function queryResultToUser(row: UserQueryResult): User {
     fullName: row.full_name || null,
     email: row.email,
     discourseUserId: row.discourse_user_id,
+    newBookingNotificationDaysThreshold: row.new_booking_notification_days_threshold,
   };
 }
 

--- a/src/backend/routes/bookingRoutes.ts
+++ b/src/backend/routes/bookingRoutes.ts
@@ -78,19 +78,11 @@ router.post<
     }
   });
 
-  // Initializing a new Date object, so setHours() does not mutate newBooking.start
-  const bookingDay = new Date(newBooking.start);
-  // Always use the beginning of the day for comparison.
-  bookingDay.setHours(0, 0, 0, 0);
-  const bookingDaysInAdvance = (bookingDay.getTime() - new Date().getTime()) / (1000 * 3600 * 24);
-  // Send notification to staff if a booking is made 14 days or less in advance
-  if (bookingDaysInAdvance <= 14) {
-    sendNewBookingNotificationToStaffs(newBooking).then((isSent) => {
-      if (!isSent) {
-        console.log(`Unable to send new booking notification for booking ${newBooking.uuid}`);
-      }
-    });
-  }
+  sendNewBookingNotificationToStaffs(newBooking).then((isSent) => {
+    if (!isSent) {
+      console.log(`Unable to send new booking notification for booking ${newBooking.uuid}`);
+    }
+  });
 
   if (newBooking.start) {
     res.status(201).json({ data: newBooking });

--- a/src/backend/routes/bookingRoutes.ts
+++ b/src/backend/routes/bookingRoutes.ts
@@ -14,7 +14,10 @@ import {
   ApiUpdateBookingParams,
   ApiBookedSlot,
 } from '../../common/constants-common';
-import { sendBookingConfirmationEmail } from '../controllers/emailControllers';
+import {
+  sendBookingConfirmationEmail,
+  sendNewBookingNotificationToStaffs,
+} from '../controllers/emailControllers';
 
 import { isAuthenticated } from '../middlewares';
 
@@ -68,13 +71,30 @@ router.post<
     return;
   }
 
+  // Not using await here in order to send email asyncronously without blocking the response
   sendBookingConfirmationEmail(newBooking).then((isSent) => {
     if (!isSent) {
       console.log(`Unable to send confirmation email for booking ${newBooking.uuid}`);
     }
   });
 
-  res.status(201).json({ data: newBooking });
+  // Initializing a new Date object, so setHours() does not mutate newBooking.start
+  const bookingDay = new Date(newBooking.start);
+  // Always use the beginning of the day for comparison.
+  bookingDay.setHours(0, 0, 0, 0);
+  const bookingDaysInAdvance = (bookingDay.getTime() - new Date().getTime()) / (1000 * 3600 * 24);
+  // Send notification to staff if a booking is made 14 days or less in advance
+  if (bookingDaysInAdvance <= 14) {
+    sendNewBookingNotificationToStaffs(newBooking).then((isSent) => {
+      if (!isSent) {
+        console.log(`Unable to send new booking notification for booking ${newBooking.uuid}`);
+      }
+    });
+  }
+
+  if (newBooking.start) {
+    res.status(201).json({ data: newBooking });
+  }
 });
 
 router.get<Record<string, never>, { data: Array<ApiBooking> } | { error: string }>(

--- a/src/backend/routes/profileRoutes.ts
+++ b/src/backend/routes/profileRoutes.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+
+import { updateUserSettings, getUserData } from '../controllers/userControllers';
+import { UserRole } from '../../common/constants-common';
+import { ApiUserData } from '../../common/constants-common';
+import { isAuthenticated } from '../middlewares';
+
+const router = express.Router();
+
+router.put<
+  Record<string, never>,
+  { data: ApiUserData } | { error: string },
+  { newBookingNotificationDaysThreshold: number | null }
+>(
+  '/',
+  // Only allow staff user to edit their own setting for now
+  isAuthenticated([UserRole.staff]),
+  async (req, res) => {
+    const user = req.user;
+    const { newBookingNotificationDaysThreshold = null } = req.body ?? {};
+    const updatedUser = await updateUserSettings({
+      // The isAuthenticated middleware already ensures user is available here
+      // eslint-disable-next-line
+      uuid: user!.uuid,
+      newBookingNotificationDaysThreshold,
+    });
+    if (!updatedUser) {
+      res.status(400).json({ error: `unable to update user profile` });
+      return;
+    }
+    res.status(201).json({ data: updatedUser });
+  },
+);
+
+router.get<Record<string, never>, { data: ApiUserData | null } | { error: string }>(
+  '/',
+  // Only allow staff user to view their own setting for now
+  isAuthenticated([UserRole.staff]),
+  async (req, res) => {
+    // The isAuthenticated middleware already ensures user is available here
+    // eslint-disable-next-line
+    const userUuid = req.user!.uuid;
+    const userData = await getUserData(userUuid);
+    if (!userData) {
+      res.status(404).json({ error: `unable to get user profile` });
+    }
+    res.status(200).json({ data: userData });
+  },
+);
+
+export default router;

--- a/src/backend/routes/userRoutes.ts
+++ b/src/backend/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import { getApiUsers, updateApiUserRole, updateUserSettings } from '../controllers/userControllers';
+import { getApiUsers, updateApiUserRole } from '../controllers/userControllers';
 import { UserRole } from '../../common/constants-common';
 import { ApiUserData } from '../../common/constants-common';
 import { isAuthenticated } from '../middlewares';
@@ -32,31 +32,6 @@ router.put<{ uuid: string }, { data: ApiUserData } | { error: string }, { role: 
     const updatedUser = await updateApiUserRole({ uuid: req.params.uuid, role: req.body.role });
     if (!updatedUser) {
       res.status(400).json({ error: `unable to update user` });
-      return;
-    }
-    res.status(201).json({ data: updatedUser });
-  },
-);
-
-router.put<
-  Record<string, never>,
-  { data: ApiUserData } | { error: string },
-  { newBookingNotificationDaysThreshold: number | null }
->(
-  '/profile/settings',
-  // Only allow staff user to edit their own setting for now
-  isAuthenticated([UserRole.staff]),
-  async (req, res) => {
-    const user = req.user;
-    const { newBookingNotificationDaysThreshold = null } = req.body ?? {};
-    const updatedUser = await updateUserSettings({
-      // The isAuthenticated middleware already ensures user is available here
-      // eslint-disable-next-line
-      uuid: user!.uuid,
-      newBookingNotificationDaysThreshold,
-    });
-    if (!updatedUser) {
-      res.status(400).json({ error: `unable to update user settings` });
       return;
     }
     res.status(201).json({ data: updatedUser });

--- a/src/backend/routes/userRoutes.ts
+++ b/src/backend/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import { getApiUsers, updateApiUserRole } from '../controllers/userControllers';
+import { getApiUsers, updateApiUserRole, updateUserSettings } from '../controllers/userControllers';
 import { UserRole } from '../../common/constants-common';
 import { ApiUserData } from '../../common/constants-common';
 import { isAuthenticated } from '../middlewares';
@@ -32,6 +32,31 @@ router.put<{ uuid: string }, { data: ApiUserData } | { error: string }, { role: 
     const updatedUser = await updateApiUserRole({ uuid: req.params.uuid, role: req.body.role });
     if (!updatedUser) {
       res.status(400).json({ error: `unable to update user` });
+      return;
+    }
+    res.status(201).json({ data: updatedUser });
+  },
+);
+
+router.put<
+  Record<string, never>,
+  { data: ApiUserData } | { error: string },
+  { newBookingNotificationDaysThreshold: number | null }
+>(
+  '/profile/settings',
+  // Only allow staff user to edit their own setting for now
+  isAuthenticated([UserRole.staff]),
+  async (req, res) => {
+    const user = req.user;
+    const { newBookingNotificationDaysThreshold = null } = req.body ?? {};
+    const updatedUser = await updateUserSettings({
+      // The isAuthenticated middleware already ensures user is available here
+      // eslint-disable-next-line
+      uuid: user!.uuid,
+      newBookingNotificationDaysThreshold,
+    });
+    if (!updatedUser) {
+      res.status(400).json({ error: `unable to update user settings` });
       return;
     }
     res.status(201).json({ data: updatedUser });

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -19,6 +19,7 @@ export interface ApiUserData {
   role: UserRole;
   fullName: string | null;
   created: string;
+  newBookingNotificationDaysThreshold?: number | null;
 }
 
 export enum LetterStatus {

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -181,4 +181,8 @@ export interface ApiPage {
   content: string;
 }
 
+export interface ApiUpdateUserSettingsParams {
+  newBookingNotificationDaysThreshold: number | null;
+}
+
 export type ApiUpdatePageParams = Omit<ApiPage, 'uuid'>;

--- a/src/frontend/Admin.tsx
+++ b/src/frontend/Admin.tsx
@@ -10,6 +10,7 @@ import { BookingTypes } from './pages/BookingTypes';
 import { Booking } from './pages/Booking';
 import { MyBookings } from './pages/MyBookings';
 import { AllBookings } from './pages/AllBookings';
+import { ProfileSettings } from './pages/ProfileSettings';
 
 export const Admin: React.FunctionComponent<RouteComponentProps> = () => {
   const { token, user } = useAuth();
@@ -25,6 +26,7 @@ export const Admin: React.FunctionComponent<RouteComponentProps> = () => {
       <Booking path="booking" />
       <MyBookings path="my-bookings" />
       <AllBookings path="all-bookings" />
+      <ProfileSettings path="settings" />
     </Router>
   );
 };

--- a/src/frontend/Navigation.tsx
+++ b/src/frontend/Navigation.tsx
@@ -67,6 +67,9 @@ const MainMenu = () => {
             <li>
               <Link to="admin/my-bookings">My bookings</Link>
             </li>
+            <li>
+              <Link to="admin/settings">Settings</Link>
+            </li>
           </>
         )}
         {user && user.role === UserRole.volunteer && (

--- a/src/frontend/pages/AllBookings.tsx
+++ b/src/frontend/pages/AllBookings.tsx
@@ -92,15 +92,6 @@ export const AllBookings: React.FC<RouteComponentProps> = () => {
               user,
               workingRemotely,
             }) => {
-              console.log(
-                moment(start).format('HH:mm'),
-                '===',
-                start,
-                ' | ',
-                moment(end).format('HH:mm'),
-                '===',
-                end,
-              );
               return (
                 <tr key={uuid}>
                   <td>{bookingType.name}</td>

--- a/src/frontend/pages/ProfileSettings.tsx
+++ b/src/frontend/pages/ProfileSettings.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useState, useEffect } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { Formik, Field, Form } from 'formik';
+
+import { ApiUserData } from '../../common/constants-common';
+import { useRequest } from '../http';
+import { useNotifications } from '../NotificationsContext';
+
+export const ProfileSettings: React.FC<RouteComponentProps> = () => {
+  const { getRequest, putRequest } = useRequest();
+  const { addNotification } = useNotifications();
+  const [userData, setUserData] = useState<ApiUserData | null>(null);
+
+  const initialFormValues = {
+    newBookingNotificationDaysThreshold:
+      userData && userData.newBookingNotificationDaysThreshold
+        ? userData.newBookingNotificationDaysThreshold
+        : 0,
+  };
+
+  const fetchProfileInfo = useCallback(async () => {
+    const result = await getRequest<{ data: ApiUserData }>('/api/profile', {
+      useJwt: true,
+    });
+    if (result.data.data) {
+      setUserData(result.data.data);
+    } else {
+      setUserData(null);
+    }
+  }, [setUserData, getRequest]);
+
+  useEffect(() => {
+    fetchProfileInfo();
+    // Fetch profile info on first mount
+    // eslint-disable-next-line
+  }, []);
+  return (
+    <div className="width-100">
+      <h1>Notification settings</h1>
+      {userData && (
+        <Formik
+          initialValues={initialFormValues}
+          onSubmit={async ({ newBookingNotificationDaysThreshold }) => {
+            const sanitizedThreshold =
+              newBookingNotificationDaysThreshold < 1 ? null : newBookingNotificationDaysThreshold;
+            const result = await putRequest<{ data: ApiUserData }>(
+              '/api/profile',
+              {
+                newBookingNotificationDaysThreshold: sanitizedThreshold,
+              },
+              { useJwt: true },
+            );
+            if (
+              result?.data?.data &&
+              result.data.data.newBookingNotificationDaysThreshold === sanitizedThreshold
+            ) {
+              addNotification({
+                type: 'success',
+                message: 'New booking notification setting updated',
+              });
+            } else {
+              addNotification({
+                type: 'error',
+                message: 'Failed to update booking notification setting.',
+              });
+            }
+          }}
+        >
+          <Form>
+            <div className="field max-width-s">
+              <label htmlFor="new-booking-days-threshold">
+                Day threshold for receiving new booking notifications. For example, if this is set
+                to 5, you will receive an email notification whenever a booking is made 5 or less
+                days before the start of the slot. The aim is to keep you up to date with
+                last-minute bookings. To disable notifications to your email, set this to 0.
+              </label>
+              <Field
+                id="new-booking-days-threshold"
+                type="number"
+                name="newBookingNotificationDaysThreshold"
+                className="max-width-xs"
+                required
+              />
+            </div>
+            <button type="submit" className="button button-info">
+              Save
+            </button>
+          </Form>
+        </Formik>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
- Add email notification to staff user about bookings that are only made a certain days before the slot date. This is to that staff are notified early about last-minute booking (that are made only 1 or 2 days in advance for example)
- Added `newBookingNotificationDaysThreshold ` field that allow staff to adjust the amount of days in advance a booking is made.
- Added a "Settings" page in the dashboard for staff to adjust this value. By default, this is disabled for all users and needed to be turned on manually.