### PR TITLE
Implement logout on idle

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -8,6 +8,10 @@ export PORT=9000
 # Admin > Settings > Login, and look for `sso provider secrets` field, and copy the secret value for `localhost`
 export DISCOURSE_URL=
 export DISCOURSE_SSO_SECRET=
+export DISCOURSE_API_KEY=
+export DISCOURSE_API_USER=
+
+export REDIS_URL=redis://localhost:6379
 
 # Set these variables if you are planning to test sending real emails
 export SENDGRID_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -24623,6 +24623,12 @@
         "use-sidecar": "^1.0.5"
       }
     },
+    "react-idle-timer": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-4.6.4.tgz",
+      "integrity": "sha512-iq61dPud8fgj7l1KOJEY5pyiD532fW0KcIe/5XUe/0lB/4Vytoy4tZBlLGSiYodPzKxTL6HyKoOmG6tyzjD7OQ==",
+      "dev": true
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16753,6 +16753,18 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isomorphic-ws": {
@@ -18328,6 +18340,14 @@
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "jwt-redis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-redis/-/jwt-redis-6.0.0.tgz",
+      "integrity": "sha512-1cUmlFQtboZ+/LkXXEhXRg7fe6cenVdIF2oN4WZmRzmaEj3wNgV0aRfprYEzvAV7bzdcU4uTx8h2UJGwHLRfLg==",
+      "requires": {
+        "jsonwebtoken": "^8.5.1"
       }
     },
     "keypress": {
@@ -20924,13 +20944,32 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-forge": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "express-winston": "^4.0.3",
     "generate-password": "^1.5.1",
     "jsonwebtoken": "^8.5.1",
+    "jwt-redis": "^6.0.0",
+    "node-fetch": "^2.6.7",
     "npm": "^7.16.0",
     "pg": "^8.2.1",
     "redis": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react": "^17.0.2",
     "react-day-picker": "^7.4.10",
     "react-dom": "^17.0.2",
+    "react-idle-timer": "^4.6.4",
     "react-modal": "^3.14.4",
     "react-scripts": "4.0.3",
     "react-select-search": "^2.0.3",

--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -86,11 +86,12 @@ export function createApp() {
   app.use('/', express.static(path.join(__dirname, '../../build')));
 
   app.use(
-    jwt({ secret: jwtSecret, algorithms: ['HS256'] }).unless({
+    jwt({
+      secret: jwtSecret,
+      algorithms: ['HS256'],
+    }).unless({
       path: [
-        '/api/auth',
         '/api/auth/sso',
-        '/api/auth/logout',
         '/api/auth/sso/verify',
         /^\/api\/auth\/token\/.*/,
         '/api/online-letter/start',

--- a/src/backend/auth.ts
+++ b/src/backend/auth.ts
@@ -1,9 +1,12 @@
 import { Request } from 'express';
-import jwt from 'jsonwebtoken';
+import redis from 'redis';
+import JWTR from 'jwt-redis';
+// @ts-ignore
+const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
 import { getConfig } from './config';
 import { hmacSha256, encodeString, getQueryData, generateRandomString } from './utils';
-import { UpsertUserParams } from './models/users';
+import { UpsertUserParams, getUserByUuid } from './models/users';
 
 export interface DiscourseSsoData {
   admin?: string;
@@ -99,22 +102,32 @@ export function validateSsoRequest(req: Request) {
   return isValidSignature && isValidNonce;
 }
 
-type TokenData = {
+export type TokenData = {
   uuid: string;
   email: string;
   fullName: string | null;
   role: string;
+  jti?: string;
 };
+
+let jwtr: JWTR | null = null;
+
+export function getJwtr() {
+  if (!jwtr) {
+    const { redisUrl } = getConfig();
+    const redisClient = redis.createClient({ url: redisUrl });
+    jwtr = new JWTR(redisClient);
+  }
+  return jwtr;
+}
 
 // Create a JWT token
 export async function createToken(data: TokenData): Promise<string | null> {
   try {
     const { jwtSecret } = getConfig();
-    // token will expire in 7 days
-    // TODO: would be better to have short-lived token and a long-live
-    // refresh token that is used to refresh token when the long-lived
-    // one exprired.
-    const token = await jwt.sign(data, jwtSecret, { expiresIn: '7d' });
+    const jwtr = getJwtr();
+    // token will expire in 1 day
+    const token = await jwtr.sign(data, jwtSecret, { expiresIn: '1 day' });
     return token;
   } catch (err) {
     console.error('Failed to create token');
@@ -139,4 +152,32 @@ export function generateUserDataFromSsoRequest(req: Request): UpsertUserParams |
     };
   }
   return null;
+}
+
+export async function logUserOutOfDiscourse(uuid: string): Promise<boolean> {
+  try {
+    const { discourseApiKey, discourseApiUser } = getConfig();
+    const u = await getUserByUuid(uuid);
+    if (!u) {
+      return false;
+    }
+    const { discourseUrl } = getConfig();
+    const response = await fetch(`${discourseUrl}/admin/users/${u.discourseUserId}/log_out.json`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': discourseApiKey,
+        'Api-Username': discourseApiUser,
+      },
+    });
+    const status = response.status;
+    if (status !== 200) {
+      console.log('unable to log user out of Discourse. Request status code: ', status);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.log('unable to log user out of Discourse: ', error);
+    return false;
+  }
 }

--- a/src/backend/auth.ts
+++ b/src/backend/auth.ts
@@ -122,13 +122,15 @@ export function getJwtr() {
 }
 
 // Create a JWT token
-export async function createToken(data: TokenData): Promise<string | null> {
+export async function createToken(data: TokenData): Promise<{ token: string; exp: number } | null> {
   try {
     const { jwtSecret } = getConfig();
     const jwtr = getJwtr();
     // token will expire in 16 minutes
     const token = await jwtr.sign(data, jwtSecret, { expiresIn: '16 minutes' });
-    return token;
+    await jwtr.verify(token, jwtSecret);
+    const { exp } = await jwtr.decode(token);
+    return { token, exp: exp as number };
   } catch (err) {
     console.error('Failed to create token');
     console.error(err);

--- a/src/backend/auth.ts
+++ b/src/backend/auth.ts
@@ -126,8 +126,8 @@ export async function createToken(data: TokenData): Promise<string | null> {
   try {
     const { jwtSecret } = getConfig();
     const jwtr = getJwtr();
-    // token will expire in 1 day
-    const token = await jwtr.sign(data, jwtSecret, { expiresIn: '1 day' });
+    // token will expire in 16 minutes
+    const token = await jwtr.sign(data, jwtSecret, { expiresIn: '16 minutes' });
     return token;
   } catch (err) {
     console.error('Failed to create token');

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -20,10 +20,13 @@ export function getConfig() {
     'DB_PORT',
     'DISCOURSE_URL',
     'DISCOURSE_SSO_SECRET',
+    'DISCOURSE_API_KEY',
+    'DISCOURSE_API_USER',
     'COOKIE_SECRET',
     'JWT_SECRET',
     'LETTER_ACCESS_KEY_SALT',
     'LETTER_AES_KEY',
+    'REDIS_URL',
   ]);
 
   if (process.env.ENVIRONMENT !== 'production' && !process.env.FRONTEND_PORT) {
@@ -57,6 +60,8 @@ export function getConfig() {
 
     discourseUrl: process.env.DISCOURSE_URL!,
     discourseSsoSecret: process.env.DISCOURSE_SSO_SECRET!,
+    discourseApiKey: process.env.DISCOURSE_API_KEY!,
+    discourseApiUser: process.env.DISCOURSE_API_USER!,
     cookieSecret: process.env.COOKIE_SECRET!,
 
     jwtSecret: process.env.JWT_SECRET!,
@@ -69,7 +74,7 @@ export function getConfig() {
     dbHost: process.env.DB_HOST!,
     dbPort: parseInt(process.env.DB_PORT!, 10),
 
-    redisUrl: process.env.REDIS_URL || null,
+    redisUrl: process.env.REDIS_URL!,
 
     sendGridApiKey: process.env.SENDGRID_API_KEY || null,
     sendGridFromEmailAddress: process.env.SENDGRID_FROM_EMAIL_ADDRESS || null,

--- a/src/backend/middlewares.ts
+++ b/src/backend/middlewares.ts
@@ -5,8 +5,12 @@ export const isAuthenticated =
   (roles: Array<UserRole> = []) =>
   (req: Request, res: Response, next: NextFunction) => {
     const { user } = req;
-    if (!user || (roles.length > 0 && !roles.includes(user.role))) {
+    if (!user) {
       res.status(401).json({ error: 'unauthorized' });
+      return;
+    }
+    if (roles.length > 0 && !roles.includes(user.role)) {
+      res.status(403).json({ error: 'forbidden' });
       return;
     }
     return next();

--- a/src/frontend/AuthContext.tsx
+++ b/src/frontend/AuthContext.tsx
@@ -121,8 +121,6 @@ export const AuthContextWrapper: React.FunctionComponent = ({ children }) => {
     async function checkToken() {
       try {
         const now = Math.floor(new Date().getTime() / 1000);
-        console.log('NOW', now, tokenExpirationTime);
-        console.log('TICKING');
         if (now >= (tokenExpirationTime as number) - 60) {
           const result = await axios.post<
             unknown,

--- a/src/frontend/FetchToken.tsx
+++ b/src/frontend/FetchToken.tsx
@@ -15,11 +15,15 @@ export const FetchToken = (props: RouteComponentProps<{ nonce?: string }>) => {
     const source = axios.CancelToken.source();
     const getToken = async (nonce: string) => {
       try {
-        const result = await getRequest<{ data: { token: string } }>(`/api/auth/token/${nonce}`, {
-          withCredentials: true,
-          cancelToken: source.token,
-        });
-        setToken(result.data.data.token);
+        const result = await getRequest<{ data: { token: string; expiresAt: number } }>(
+          `/api/auth/token/${nonce}`,
+          {
+            withCredentials: true,
+            cancelToken: source.token,
+          },
+        );
+        const { token, expiresAt } = result.data.data;
+        setToken(token, expiresAt);
         setDone(true);
       } catch (err) {
         setDone(true);

--- a/src/frontend/http.ts
+++ b/src/frontend/http.ts
@@ -14,7 +14,20 @@ const defaultHeaders = {
 };
 
 export function useRequest() {
-  const { token, setToken } = useAuth();
+  const { token, setToken, logout } = useAuth();
+
+  const handleError = useCallback(
+    (err: unknown): void => {
+      // @ts-ignore
+      if (err && err.response?.status === 401) {
+        logout();
+        if (token) {
+          setToken(null, null);
+        }
+      }
+    },
+    [logout, token, setToken],
+  );
 
   const getRequest = useCallback(
     async function <T = unknown, R = AxiosResponse<T>>(
@@ -35,13 +48,11 @@ export function useRequest() {
         });
         return result;
       } catch (err) {
-        if (isInvalidTokenError(err)) {
-          setToken(null);
-        }
+        handleError(err);
         throw err;
       }
     },
-    [token, setToken],
+    [token, handleError],
   );
 
   const putRequest = useCallback(
@@ -63,13 +74,11 @@ export function useRequest() {
           },
         });
       } catch (err) {
-        if (isInvalidTokenError(err)) {
-          setToken(null);
-        }
+        handleError(err);
         throw err;
       }
     },
-    [token, setToken],
+    [token, handleError],
   );
 
   const postRequest = useCallback(
@@ -92,13 +101,11 @@ export function useRequest() {
         });
         return result;
       } catch (err) {
-        if (isInvalidTokenError(err)) {
-          setToken(null);
-        }
+        handleError(err);
         throw err;
       }
     },
-    [token, setToken],
+    [token, handleError],
   );
 
   const deleteRequest = useCallback(
@@ -120,18 +127,12 @@ export function useRequest() {
         });
         return result;
       } catch (err) {
-        if (isInvalidTokenError(err)) {
-          setToken(null);
-        }
+        handleError(err);
         throw err;
       }
     },
-    [token, setToken],
+    [token, handleError],
   );
 
   return { getRequest, putRequest, postRequest, deleteRequest };
-}
-
-function isInvalidTokenError(err: unknown) {
-  return axios.isAxiosError(err) && err.response?.data?.error === 'invalid jwt token';
 }


### PR DESCRIPTION
- Use jwt-redis to support token invokation
- Token expiration time are now at 15 minutes
- Implement auto-refresh token when the current token is expiring.
- Use sessionStorage to store token instead of localStorage
- Implement remote Discourse logout when a token is invoked
- Automatically logout if user is idle for 15 minutes.