### PR TITLE
Fix multiple timezone problems

### DIFF
--- a/src/frontend/BookingCalendar/BookingCalendar.tsx
+++ b/src/frontend/BookingCalendar/BookingCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import moment, { Moment } from 'moment-timezone';
 import styled from 'styled-components';
 import {
@@ -29,9 +29,6 @@ type BookingCalendarProps = {
   bookingTypes: Array<ApiBookingType>;
 };
 
-// Give current date in Finnish (since default timezone was already set in App.tsx)
-const currentDate = moment();
-
 const bookingTypeColors = [
   'rgba(192, 46, 29, 0.9)',
   'rgba(13, 84, 73, 0.9)',
@@ -42,6 +39,11 @@ const bookingTypeColors = [
 ];
 
 export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }) => {
+  // Give current date in Finnish (since default timezone was already set in App.tsx)
+  // This has to be inside this component because on the main level the default time zone
+  // is not set yet.
+  const currentDate = useRef(moment()).current;
+
   const [startDate, setStartDate] = useState(currentDate.startOf('week'));
   const [selectedBookingTypes, setSelectedBookingTypes] = useState<Array<string>>([]);
   const [bookingDetails, setBookingDetails] = useState<BookingSlotDetails | null>(null);

--- a/src/frontend/ExceptionsDatePicker/ExceptionsDatePicker.tsx
+++ b/src/frontend/ExceptionsDatePicker/ExceptionsDatePicker.tsx
@@ -17,11 +17,13 @@ const ExceptionsDatePicker: React.FC<ExceptionsDatePickerProps> = ({
 }) => {
   const [{ value: exceptions }, , { setValue }] = useField<Array<string>>('exceptions');
   const [{ value: rules }] = useField('rules');
-  const dateExceptions = exceptions.map(
-    (exceptionDateString: string) => new Date(exceptionDateString),
-  );
+
+  // exceptions is list of "2022-12-30" formatted strings
+  // dateExceptions is list of Date objects which point to the NOON IN BROWSER'S LOCAL TIMEZONE
+  const dateExceptions = exceptions.map(storedDateToLocalNoon);
 
   const handleDayClick = (day: Date, { selected, disabled }: DayModifiers) => {
+    // day points to the local noon of the correct date
     if (disabled) {
       return;
     }
@@ -30,7 +32,7 @@ const ExceptionsDatePicker: React.FC<ExceptionsDatePickerProps> = ({
 
     if (selected) {
       const selectedIndex = exceptions.findIndex((selectedItem) =>
-        DateUtils.isSameDay(new Date(selectedItem), day),
+        DateUtils.isSameDay(storedDateToLocalNoon(selectedItem), day),
       );
       newExceptions.splice(selectedIndex, 1);
     } else {
@@ -84,5 +86,21 @@ const ExceptionsDatePicker: React.FC<ExceptionsDatePickerProps> = ({
     </Modal>
   );
 };
+
+/**
+ * The DayPicker library works with Dates that point to the noon
+ * in the local timezone of the browser. This function converts a
+ * string in form "2022-01-30" into a Date object.
+ */
+function storedDateToLocalNoon(dateString: string): Date {
+  const dateSplit = (/^(\d\d\d\d)-(\d\d)-(\d\d)$/).exec(dateString);
+  if (!dateSplit) {
+    throw new Error("Invalid exception date " + dateString);
+  }
+  const year = parseInt(dateSplit[1]);
+  const month = parseInt(dateSplit[2]);
+  const day = parseInt(dateSplit[3]);
+  return new Date(year, month - 1, day, 12, 0, 0);
+}
 
 export default ExceptionsDatePicker;

--- a/src/frontend/Letters.tsx
+++ b/src/frontend/Letters.tsx
@@ -10,6 +10,7 @@ import { useAuth } from './AuthContext';
 import { useRequest } from './http';
 
 import './assets/react-select-search.css';
+import moment from 'moment-timezone';
 
 const LettersTable = styled.table`
   tr {
@@ -111,7 +112,7 @@ export const Letters: React.FunctionComponent<RouteComponentProps> = () => {
           {letters.map((letter) => {
             return (
               <tr key={`letter-list-item-${letter.uuid}`}>
-                <td>{new Date(letter.created).toLocaleString()}</td>
+                <td>{moment(letter.created).format('dddd DD/MM/YYYY, HH:mm')}</td>
                 <td>
                   <Link to={letter.uuid}>{letter.title}</Link>
                 </td>

--- a/src/frontend/Reply.tsx
+++ b/src/frontend/Reply.tsx
@@ -7,6 +7,7 @@ import { useNotifications } from './NotificationsContext';
 import { useAuth } from './AuthContext';
 import { LetterContent } from './ui-components/content';
 import { Button, ButtonText } from './ui-components/buttons';
+import moment from 'moment-timezone';
 
 export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: string }>> = ({
   letterUuid,
@@ -150,7 +151,7 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
       <h1>{letter.title}</h1>
       <p>
         <i>
-          <b>Created:</b> {new Date(letter.created).toLocaleString('en-GB')}
+          <b>Created:</b> {moment(letter.created).format('dddd DD/MM/YYYY, HH:mm')}
         </i>
       </p>
       <LetterContent>{letter.content}</LetterContent>
@@ -159,7 +160,7 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
       {reply && (
         <p>
           <i>
-            <b>Updated on:</b> {new Date(reply.updated).toLocaleString('en-GB')}
+            <b>Updated on:</b> {reply.updated ? moment(reply.updated).format('dddd DD/MM/YYYY, HH:mm') : 'never'}
           </i>
           <br />
           <i>

--- a/src/frontend/pages/BookingTypeForm.tsx
+++ b/src/frontend/pages/BookingTypeForm.tsx
@@ -12,9 +12,9 @@ import {
 } from '../../common/constants-common';
 
 import { useNotifications } from '../NotificationsContext';
-import { format } from 'date-fns';
 import ExceptionsDatePicker from '../ExceptionsDatePicker/ExceptionsDatePicker';
 import { useRequest } from '../http';
+import moment from 'moment-timezone';
 
 interface BookingTypeFormProps {
   bookingType?: ApiBookingType;
@@ -173,7 +173,7 @@ export const BookingTypeForm: React.FC<BookingTypeFormProps> = ({
                                 key={`exception.${idx}`}
                               >
                                 <p className="font-size-xs no-margin padding-right-s">
-                                  {format(new Date(exceptionDateString), 'dd.MM.yyyy')}
+                                  {moment(exceptionDateString).format('DD.MM.yyyy')}
                                 </p>
                                 <button
                                   className="button button-tertiary button-text button-xxs"

--- a/src/frontend/pages/BookingTypes.tsx
+++ b/src/frontend/pages/BookingTypes.tsx
@@ -5,7 +5,7 @@ import { ApiBookingType, weekDays } from '../../common/constants-common';
 import { useRequest } from '../http';
 import { useNotifications } from '../NotificationsContext';
 import { BookingTypeForm } from './BookingTypeForm';
-import { format } from 'date-fns';
+import moment from 'moment-timezone';
 
 export const BookingTypes: React.FunctionComponent<RouteComponentProps> = () => {
   const [isCreatingNew, setIsCreatingNew] = useState<boolean>(false);
@@ -132,7 +132,7 @@ export const BookingTypes: React.FunctionComponent<RouteComponentProps> = () => 
                               key={`exception-${idx}`}
                               className="border-radius background-error-50 padding-xxs font-size-xxs font-weight-semibold"
                             >
-                              {format(new Date(exceptionDateString), 'dd.MM.yyyy')}
+                              {moment(exceptionDateString).format('DD.MM.yyyy')}
                             </div>
                           </li>
                         ))}

--- a/src/start-backend.ts
+++ b/src/start-backend.ts
@@ -1,3 +1,4 @@
+process.env.TZ = 'UTC'; // Set the backend application to use UTC time everywhere.
 import { getConfig } from './backend/config';
 import { createApp } from './backend/app';
 


### PR DESCRIPTION
- Resolves #68, the bookings are now registered for correct time regardless of the user's local timezone settings. (Reason: a moment.js date object was created before the default timezone had been set)
- Modified letter list and single letter page to always show the time in Europe/Helsinki timezone, making it consistent with the rest of the application
- Fixed timezone problem in exceptions of booking types/slots. Previously if the timezone was negative from UTC (e.g. somewhere in America) the exceptions pointed to wrong days because midnight in UTC is previous day in -01:00. Works correctly now, dates are always in `Europe/Helsinki` time.
- Set the server to internally always use UTC time, this has been the case on the Heroku servers, but not in local development, which caused some minor inconsistencies in how dates are stored in database. This should not need any migrations on the server because there nothing has changed, but it must be verified in dev environment before deploying to production.
- Documented timezone handling to `README.md`