### PR TITLE
Add profile link redirecting to discourse to nav bar

### DIFF
--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -116,6 +116,7 @@ export function createApp() {
       path: [
         '/api/auth/sso',
         '/api/auth/sso/verify',
+        '/api/auth/profile-redirect',
         /^\/api\/auth\/token\/.*/,
         '/api/online-letter/start',
         '/api/online-letter/send',

--- a/src/backend/routes/authRoutes.ts
+++ b/src/backend/routes/authRoutes.ts
@@ -188,4 +188,18 @@ router.post<
   }
 });
 
+/**
+ * Redirect the user to their Discourse profile information.
+ *
+ * This can not be done on frontend because it does not know the
+ * Discourse server address, because the address is only specified
+ * in the environment variables.
+ *
+ * THIS ROUTE IS NOT PROTECTED BY ANY AUTHENTICATION
+ */
+router.get('/profile-redirect', async (req, res) => {
+  const { discourseUrl } = getConfig();
+  res.redirect(`${discourseUrl}/my/preferences/account`, 302);
+});
+
 export default router;

--- a/src/frontend/Navigation.tsx
+++ b/src/frontend/Navigation.tsx
@@ -93,6 +93,9 @@ const MainMenu: React.FC<{ afterMenuClicked: () => void }> = ({ afterMenuClicked
         {user && (
           <li>
             {user.email} ({user.role}) {` `}
+            <a href="/api/auth/profile-redirect" target="_blank" className="button button-secondary button-xxs">
+              Edit profile
+            </a>
             <ButtonSmall buttonType="secondary" onClick={logout} className="button button-xxs">
               Logout
             </ButtonSmall>


### PR DESCRIPTION
Closes #95 

- Add new button with text "Edit profile" next to the logout button
- Add endpoint `/api/auth/profile-redirect` because we can not access the `DISCOURSE_URL` environment variable from the browser code
- Redirect user to `DISCOURSE_URL/my/preferences/account`, does not require the username to be known but goes to the same page.