### PR TITLE
Feature/reply read status

### DIFF
--- a/db/migrations/20220815054204-add-recipient-status-to-replies-table.js
+++ b/db/migrations/20220815054204-add-recipient-status-to-replies-table.js
@@ -1,0 +1,37 @@
+'use strict';
+const async = require('async');
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  async.series(
+    [
+      db.addColumn.bind(db, 'replies', 'recipient_status', {
+        type: 'string',
+        notNull: true,
+        defaultValue: 'unread',
+      }),
+    ],
+    callback,
+  );
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/db/migrations/20220815110500-add-read-timestamp-to-replies-table.js
+++ b/db/migrations/20220815110500-add-read-timestamp-to-replies-table.js
@@ -1,0 +1,31 @@
+'use strict';
+const async = require('async');
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  async.series(
+    [db.addColumn.bind(db, 'replies', 'read_timestamp', { type: 'timestamp', notNull: false })],
+    callback,
+  );
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/db/migrations/20220815110500-add-read-timestamp-to-replies-table.js
+++ b/db/migrations/20220815110500-add-read-timestamp-to-replies-table.js
@@ -22,8 +22,8 @@ exports.up = function (db, callback) {
   );
 };
 
-exports.down = function (db) {
-  return null;
+exports.down = function (db, callback) {
+  async.series([db.removeColumn.bind(db, 'replies', 'read_timestamp')], callback);
 };
 
 exports._meta = {

--- a/db/migrations/20220815120952-add-read-receipt-to-replies-table.js
+++ b/db/migrations/20220815120952-add-read-receipt-to-replies-table.js
@@ -5,20 +5,10 @@ var dbm;
 var type;
 var seed;
 
-/**
- * We receive the dbmigrate dependency from dbmigrate initially.
- * This enables us to not have to rely on NODE_PATH.
- */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-};
-
 exports.up = function (db, callback) {
   async.series(
     [
-      db.addColumn.bind(db, 'replies', 'recipient_status', {
+      db.addColumn.bind(db, 'replies', 'read_receipt', {
         type: 'string',
         notNull: true,
         defaultValue: 'unread',

--- a/db/migrations/20220815120952-add-read-receipt-to-replies-table.js
+++ b/db/migrations/20220815120952-add-read-receipt-to-replies-table.js
@@ -18,8 +18,8 @@ exports.up = function (db, callback) {
   );
 };
 
-exports.down = function (db) {
-  return null;
+exports.down = function (db, callback) {
+  async.series([db.removeColumn.bind(db, 'replies', 'read_receipt')], callback);
 };
 
 exports._meta = {

--- a/db/migrations/20220816054120-add-status-timestamp-to-replies-table.js
+++ b/db/migrations/20220816054120-add-status-timestamp-to-replies-table.js
@@ -1,0 +1,38 @@
+'use strict';
+const async = require('async');
+
+var dbm;
+var type;
+var seed;
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+// The "status_timestamp" will capture the time when the reply's status is changed 
+// while the "updated" will capture the time when the reply's record is updated.
+exports.up = function (db, callback) {
+  async.series(
+    [
+      db.addColumn.bind(db, 'replies', 'status_timestamp', { type: 'timestamp', notNull: false }),
+      db.runSql.bind(
+        db,
+        `
+        --The default value of status_timestamp is the updated value
+        UPDATE replies SET status_timestamp=updated;
+      `,
+      ),
+    ],
+    callback,
+  );
+};
+
+exports.down = function (db, callback) {
+  async.series([db.removeColumn.bind(db, 'replies', 'status_timestamp')], callback);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/src/backend/controllers/letterControllers.ts
+++ b/src/backend/controllers/letterControllers.ts
@@ -110,6 +110,7 @@ export async function assignLetter({
     assignedResponderFullName,
     status,
     replyStatus,
+    replyStatusTimestamp
   } = letter;
   return {
     uuid,
@@ -121,6 +122,7 @@ export async function assignLetter({
     assignedResponderFullName,
     status,
     replyStatus,
+    replyStatusTimestamp
   };
 }
 

--- a/src/backend/controllers/replyControllers.ts
+++ b/src/backend/controllers/replyControllers.ts
@@ -25,14 +25,23 @@ export async function replyToLetter({
   internalAuthorUuid,
   authorType,
   status,
+  statusTimestamp,
 }: {
   letterUuid: string;
   content: string;
   internalAuthorUuid: string;
   authorType: ResponderType;
   status: ReplyStatus;
+  statusTimestamp: Date;
 }): Promise<ApiReplyAdmin | null> {
-  const reply = await createReply({ letterUuid, content, internalAuthorUuid, authorType, status });
+  const reply = await createReply({
+    letterUuid,
+    content,
+    internalAuthorUuid,
+    authorType,
+    status,
+    statusTimestamp,
+  });
   if (!reply) {
     return null;
   }
@@ -47,7 +56,8 @@ export async function replyToLetter({
     status,
     content,
     readReceipt,
-    readTimestamp: readTimestamp ? readTimestamp.toString() : null
+    readTimestamp: readTimestamp ? readTimestamp.toString() : null,
+    statusTimestamp: statusTimestamp ? statusTimestamp.toString() : null,
   };
 }
 
@@ -65,7 +75,8 @@ export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin
     status,
     content,
     readReceipt,
-    readTimestamp
+    readTimestamp,
+    statusTimestamp,
   } = reply;
   return {
     uuid,
@@ -77,7 +88,8 @@ export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin
     status,
     content,
     readReceipt,
-    readTimestamp: readTimestamp ? readTimestamp.toString() : null
+    readTimestamp: readTimestamp ? readTimestamp.toString() : null,
+    statusTimestamp: statusTimestamp ? statusTimestamp.toString() : null,
   };
 }
 
@@ -85,8 +97,9 @@ export async function updateLettersReply(
   replyUuid: string,
   content: string,
   status: ReplyStatus,
+  statusTimestamp: Date,
 ): Promise<ApiReplyAdmin | null> {
-  const reply = await updateReply({ uuid: replyUuid, content, status });
+  const reply = await updateReply({ uuid: replyUuid, content, status, statusTimestamp });
   if (!reply) {
     return null;
   }
@@ -100,7 +113,8 @@ export async function updateLettersReply(
     status: updatedStatus,
     content: updatedContent,
     readReceipt,
-    readTimestamp
+    readTimestamp,
+    statusTimestamp: updatedStatusTimeStamp,
   } = reply;
   return {
     uuid,
@@ -112,7 +126,8 @@ export async function updateLettersReply(
     status: updatedStatus,
     content: updatedContent,
     readReceipt,
-    readTimestamp: readTimestamp ? readTimestamp.toString() : null
+    readTimestamp: readTimestamp ? readTimestamp.toString() : null,
+    statusTimestamp: updatedStatusTimeStamp ? updatedStatusTimeStamp.toString() : null,
   };
 }
 
@@ -121,7 +136,7 @@ export async function updateLettersReplyReadReceipt(
   readReceipt: ReadReceiptStatus,
   readTimestamp: Date | null = null,
 ): Promise<boolean | null> {
-  const reply = await updateReplyReadReceipt({ uuid: replyUuid, readReceipt, readTimestamp  });
+  const reply = await updateReplyReadReceipt({ uuid: replyUuid, readReceipt, readTimestamp });
   if (!reply) {
     return null;
   }

--- a/src/backend/controllers/replyControllers.ts
+++ b/src/backend/controllers/replyControllers.ts
@@ -1,6 +1,11 @@
-import { createReply, getReply, updateReply } from '../models/replies';
+import { createReply, getReply, updateReply, updateReplyRecipientStatus } from '../models/replies';
 import { getLetterByUuid } from '../models/letters';
-import { ApiReplyAdmin, ReplyStatus, ResponderType } from '../../common/constants-common';
+import {
+  ApiReplyAdmin,
+  RecipientStatus,
+  ReplyStatus,
+  ResponderType,
+} from '../../common/constants-common';
 
 // Check if a letter is assigned a user
 export async function isUserAssignedToLetter(
@@ -31,8 +36,18 @@ export async function replyToLetter({
   if (!reply) {
     return null;
   }
-  const { uuid, created, updated } = reply;
-  return { uuid, authorType, created, updated, internalAuthorUuid, letterUuid, status, content };
+  const { uuid, created, updated, recipientStatus } = reply;
+  return {
+    uuid,
+    authorType,
+    created,
+    updated,
+    internalAuthorUuid,
+    letterUuid,
+    status,
+    content,
+    recipientStatus,
+  };
 }
 
 export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin | null> {
@@ -40,8 +55,27 @@ export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin
   if (!reply) {
     return null;
   }
-  const { uuid, authorType, created, updated, internalAuthorUuid, status, content } = reply;
-  return { uuid, authorType, created, updated, internalAuthorUuid, letterUuid, status, content };
+  const {
+    uuid,
+    authorType,
+    created,
+    updated,
+    internalAuthorUuid,
+    status,
+    content,
+    recipientStatus,
+  } = reply;
+  return {
+    uuid,
+    authorType,
+    created,
+    updated,
+    internalAuthorUuid,
+    letterUuid,
+    status,
+    content,
+    recipientStatus,
+  };
 }
 
 export async function updateLettersReply(
@@ -62,6 +96,7 @@ export async function updateLettersReply(
     letterUuid,
     status: updatedStatus,
     content: updatedContent,
+    recipientStatus,
   } = reply;
   return {
     uuid,
@@ -72,5 +107,17 @@ export async function updateLettersReply(
     letterUuid,
     status: updatedStatus,
     content: updatedContent,
+    recipientStatus,
   };
+}
+
+export async function updateLettersReplyRecipientStatus(
+  replyUuid: string,
+  recipientStatus: RecipientStatus,
+): Promise<boolean | null> {
+  const reply = await updateReplyRecipientStatus({ uuid: replyUuid, recipientStatus });
+  if (!reply) {
+    return null;
+  }
+  return true;
 }

--- a/src/backend/controllers/replyControllers.ts
+++ b/src/backend/controllers/replyControllers.ts
@@ -25,14 +25,12 @@ export async function replyToLetter({
   internalAuthorUuid,
   authorType,
   status,
-  statusTimestamp,
 }: {
   letterUuid: string;
   content: string;
   internalAuthorUuid: string;
   authorType: ResponderType;
   status: ReplyStatus;
-  statusTimestamp: Date;
 }): Promise<ApiReplyAdmin | null> {
   const reply = await createReply({
     letterUuid,
@@ -40,12 +38,11 @@ export async function replyToLetter({
     internalAuthorUuid,
     authorType,
     status,
-    statusTimestamp,
   });
   if (!reply) {
     return null;
   }
-  const { uuid, created, updated, readReceipt, readTimestamp } = reply;
+  const { uuid, created, updated, readReceipt, readTimestamp, statusTimestamp } = reply;
   return {
     uuid,
     authorType,
@@ -97,9 +94,8 @@ export async function updateLettersReply(
   replyUuid: string,
   content: string,
   status: ReplyStatus,
-  statusTimestamp: Date,
 ): Promise<ApiReplyAdmin | null> {
-  const reply = await updateReply({ uuid: replyUuid, content, status, statusTimestamp });
+  const reply = await updateReply({ uuid: replyUuid, content, status });
   if (!reply) {
     return null;
   }
@@ -114,7 +110,7 @@ export async function updateLettersReply(
     content: updatedContent,
     readReceipt,
     readTimestamp,
-    statusTimestamp: updatedStatusTimeStamp,
+    statusTimestamp,
   } = reply;
   return {
     uuid,
@@ -127,7 +123,7 @@ export async function updateLettersReply(
     content: updatedContent,
     readReceipt,
     readTimestamp: readTimestamp ? readTimestamp.toString() : null,
-    statusTimestamp: updatedStatusTimeStamp ? updatedStatusTimeStamp.toString() : null,
+    statusTimestamp: statusTimestamp ? statusTimestamp.toString() : null,
   };
 }
 

--- a/src/backend/controllers/replyControllers.ts
+++ b/src/backend/controllers/replyControllers.ts
@@ -1,8 +1,8 @@
-import { createReply, getReply, updateReply, updateReplyRecipientStatus } from '../models/replies';
+import { createReply, getReply, updateReply, updateReplyReadReceipt } from '../models/replies';
 import { getLetterByUuid } from '../models/letters';
 import {
   ApiReplyAdmin,
-  RecipientStatus,
+  ReadReceiptStatus,
   ReplyStatus,
   ResponderType,
 } from '../../common/constants-common';
@@ -36,7 +36,7 @@ export async function replyToLetter({
   if (!reply) {
     return null;
   }
-  const { uuid, created, updated, recipientStatus, readTimestamp } = reply;
+  const { uuid, created, updated, readReceipt, readTimestamp } = reply;
   return {
     uuid,
     authorType,
@@ -46,7 +46,7 @@ export async function replyToLetter({
     letterUuid,
     status,
     content,
-    recipientStatus,
+    readReceipt,
     readTimestamp: readTimestamp ? readTimestamp.toString() : null
   };
 }
@@ -64,7 +64,7 @@ export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin
     internalAuthorUuid,
     status,
     content,
-    recipientStatus,
+    readReceipt,
     readTimestamp
   } = reply;
   return {
@@ -76,7 +76,7 @@ export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin
     letterUuid,
     status,
     content,
-    recipientStatus,
+    readReceipt,
     readTimestamp: readTimestamp ? readTimestamp.toString() : null
   };
 }
@@ -99,7 +99,7 @@ export async function updateLettersReply(
     letterUuid,
     status: updatedStatus,
     content: updatedContent,
-    recipientStatus,
+    readReceipt,
     readTimestamp
   } = reply;
   return {
@@ -111,17 +111,17 @@ export async function updateLettersReply(
     letterUuid,
     status: updatedStatus,
     content: updatedContent,
-    recipientStatus,
+    readReceipt,
     readTimestamp: readTimestamp ? readTimestamp.toString() : null
   };
 }
 
-export async function updateLettersReplyRecipientStatus(
+export async function updateLettersReplyReadReceipt(
   replyUuid: string,
-  recipientStatus: RecipientStatus,
+  readReceipt: ReadReceiptStatus,
   readTimestamp: Date | null = null,
 ): Promise<boolean | null> {
-  const reply = await updateReplyRecipientStatus({ uuid: replyUuid, recipientStatus, readTimestamp  });
+  const reply = await updateReplyReadReceipt({ uuid: replyUuid, readReceipt, readTimestamp  });
   if (!reply) {
     return null;
   }

--- a/src/backend/controllers/replyControllers.ts
+++ b/src/backend/controllers/replyControllers.ts
@@ -36,7 +36,7 @@ export async function replyToLetter({
   if (!reply) {
     return null;
   }
-  const { uuid, created, updated, recipientStatus } = reply;
+  const { uuid, created, updated, recipientStatus, readTimestamp } = reply;
   return {
     uuid,
     authorType,
@@ -47,6 +47,7 @@ export async function replyToLetter({
     status,
     content,
     recipientStatus,
+    readTimestamp: readTimestamp ? readTimestamp.toString() : null
   };
 }
 
@@ -64,6 +65,7 @@ export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin
     status,
     content,
     recipientStatus,
+    readTimestamp
   } = reply;
   return {
     uuid,
@@ -75,6 +77,7 @@ export async function getLettersReply(letterUuid: string): Promise<ApiReplyAdmin
     status,
     content,
     recipientStatus,
+    readTimestamp: readTimestamp ? readTimestamp.toString() : null
   };
 }
 
@@ -97,6 +100,7 @@ export async function updateLettersReply(
     status: updatedStatus,
     content: updatedContent,
     recipientStatus,
+    readTimestamp
   } = reply;
   return {
     uuid,
@@ -108,14 +112,16 @@ export async function updateLettersReply(
     status: updatedStatus,
     content: updatedContent,
     recipientStatus,
+    readTimestamp: readTimestamp ? readTimestamp.toString() : null
   };
 }
 
 export async function updateLettersReplyRecipientStatus(
   replyUuid: string,
   recipientStatus: RecipientStatus,
+  readTimestamp: Date | null = null,
 ): Promise<boolean | null> {
-  const reply = await updateReplyRecipientStatus({ uuid: replyUuid, recipientStatus });
+  const reply = await updateReplyRecipientStatus({ uuid: replyUuid, recipientStatus, readTimestamp  });
   if (!reply) {
     return null;
   }

--- a/src/backend/models/letters.ts
+++ b/src/backend/models/letters.ts
@@ -39,9 +39,9 @@ export interface LetterQueryResult {
   assigned_responder_full_name?: string;
   title_iv: string;
   content_iv: string;
-  read_receipt?: ReadReceiptStatus;
-  read_timestamp?: string;
-  status_timestamp?: string;
+  reply_read_receipt?: ReadReceiptStatus;
+  reply_read_timestamp?: string;
+  reply_status_timestamp?: string;
 }
 
 function queryResultToLetter(row: LetterQueryResult): Letter {
@@ -61,9 +61,9 @@ function queryResultToLetter(row: LetterQueryResult): Letter {
     assignedResponderEmail: row.assigned_responder_email || null,
     assignedResponderFullName: row.assigned_responder_full_name || null,
     replyStatus: row.reply_status || null,
-    replyReadReceipt: row.read_receipt || null,
-    replyReadTimestamp: row.read_timestamp || null, 
-    replyStatusTimestamp: row.status_timestamp || null, 
+    replyReadReceipt: row.reply_read_receipt || null,
+    replyReadTimestamp: row.reply_read_timestamp || null, 
+    replyStatusTimestamp: row.reply_status_timestamp || null, 
   };
 }
 

--- a/src/backend/models/letters.ts
+++ b/src/backend/models/letters.ts
@@ -20,6 +20,7 @@ export interface Letter {
   replyStatus: ReplyStatus | null;
   replyReadReceipt: ReadReceiptStatus | null;
   replyReadTimestamp: string | null;
+  replyStatusTimestamp: string | null;
 }
 
 export interface LetterQueryResult {
@@ -40,6 +41,7 @@ export interface LetterQueryResult {
   content_iv: string;
   read_receipt?: ReadReceiptStatus;
   read_timestamp?: string;
+  status_timestamp?: string;
 }
 
 function queryResultToLetter(row: LetterQueryResult): Letter {
@@ -61,6 +63,7 @@ function queryResultToLetter(row: LetterQueryResult): Letter {
     replyStatus: row.reply_status || null,
     replyReadReceipt: row.read_receipt || null,
     replyReadTimestamp: row.read_timestamp || null, 
+    replyStatusTimestamp: row.status_timestamp || null, 
   };
 }
 
@@ -74,7 +77,8 @@ export async function getAssignedLetters(userUuid: string): Promise<Array<Letter
          users.full_name as assigned_responder_full_name,
          replies.status as reply_status,
          replies.read_receipt,
-         replies.read_timestamp
+         replies.read_timestamp,
+         replies.status_timestamp
        FROM letters
        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
        LEFT OUTER JOIN replies ON letters.uuid = replies.letter_uuid
@@ -105,7 +109,8 @@ export async function getSentLetters(): Promise<Array<Letter> | null> {
          users.full_name as assigned_responder_full_name,
          replies.status as reply_status,
          replies.read_receipt,
-         replies.read_timestamp
+         replies.read_timestamp,
+         replies.status_timestamp
        FROM letters
        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
        LEFT OUTER JOIN replies ON letters.uuid = replies.letter_uuid
@@ -123,31 +128,6 @@ export async function getSentLetters(): Promise<Array<Letter> | null> {
     return null;
   }
 }
-
-// TODO: remove this
-// export async function getLetters(): Promise<Array<Letter> | null> {
-//   try {
-//     // Fetch the letter using the unique accessKeyHash
-//     const queryText = `
-//        SELECT
-//          letters.*,
-//          users.email as assigned_responder_email,
-//          users.full_name as assigned_responder_full_name
-//        FROM letters
-//        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
-//        ORDER BY id DESC;
-//     `;
-//     const result = await db.query<LetterQueryResult>(queryText, []);
-//     if (result.rows.length < 1) {
-//       return null;
-//     }
-//     return result.rows.map((r) => queryResultToLetter(r));
-//   } catch (err) {
-//     console.error('Failed to fetch letter by accessKey');
-//     console.error(err);
-//     return null;
-//   }
-// }
 
 // Generate a new letter with random accessKey and accessPassword
 // Returning the original form of both keys

--- a/src/backend/models/letters.ts
+++ b/src/backend/models/letters.ts
@@ -2,7 +2,7 @@ import db from '../db';
 import { generate as generatePass } from 'generate-password';
 
 import { saltHash, generateRandomString, aesDecrypt, aesEncrypt } from '../utils';
-import { LetterStatus, ApiLetterCredentials, ReplyStatus } from '../../common/constants-common';
+import { LetterStatus, ApiLetterCredentials, ReplyStatus, ReadReceiptStatus } from '../../common/constants-common';
 import { getConfig } from '../config';
 
 export interface Letter {
@@ -18,6 +18,8 @@ export interface Letter {
   created: string;
   status: LetterStatus;
   replyStatus: ReplyStatus | null;
+  replyReadReceipt: ReadReceiptStatus | null;
+  replyReadTimestamp: string | null;
 }
 
 export interface LetterQueryResult {
@@ -36,6 +38,8 @@ export interface LetterQueryResult {
   assigned_responder_full_name?: string;
   title_iv: string;
   content_iv: string;
+  read_receipt?: ReadReceiptStatus;
+  read_timestamp?: string;
 }
 
 function queryResultToLetter(row: LetterQueryResult): Letter {
@@ -55,6 +59,8 @@ function queryResultToLetter(row: LetterQueryResult): Letter {
     assignedResponderEmail: row.assigned_responder_email || null,
     assignedResponderFullName: row.assigned_responder_full_name || null,
     replyStatus: row.reply_status || null,
+    replyReadReceipt: row.read_receipt || null,
+    replyReadTimestamp: row.read_timestamp || null, 
   };
 }
 
@@ -66,7 +72,9 @@ export async function getAssignedLetters(userUuid: string): Promise<Array<Letter
          letters.*,
          users.email as assigned_responder_email,
          users.full_name as assigned_responder_full_name,
-         replies.status as reply_status
+         replies.status as reply_status,
+         replies.read_receipt,
+         replies.read_timestamp
        FROM letters
        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
        LEFT OUTER JOIN replies ON letters.uuid = replies.letter_uuid
@@ -95,7 +103,9 @@ export async function getSentLetters(): Promise<Array<Letter> | null> {
          letters.*,
          users.email as assigned_responder_email,
          users.full_name as assigned_responder_full_name,
-         replies.status as reply_status
+         replies.status as reply_status,
+         replies.read_receipt,
+         replies.read_timestamp
        FROM letters
        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
        LEFT OUTER JOIN replies ON letters.uuid = replies.letter_uuid
@@ -114,29 +124,30 @@ export async function getSentLetters(): Promise<Array<Letter> | null> {
   }
 }
 
-export async function getLetters(): Promise<Array<Letter> | null> {
-  try {
-    // Fetch the letter using the unique accessKeyHash
-    const queryText = `
-       SELECT
-         letters.*,
-         users.email as assigned_responder_email,
-         users.full_name as assigned_responder_full_name
-       FROM letters
-       LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
-       ORDER BY id DESC;
-    `;
-    const result = await db.query<LetterQueryResult>(queryText, []);
-    if (result.rows.length < 1) {
-      return null;
-    }
-    return result.rows.map((r) => queryResultToLetter(r));
-  } catch (err) {
-    console.error('Failed to fetch letter by accessKey');
-    console.error(err);
-    return null;
-  }
-}
+// TODO: remove this
+// export async function getLetters(): Promise<Array<Letter> | null> {
+//   try {
+//     // Fetch the letter using the unique accessKeyHash
+//     const queryText = `
+//        SELECT
+//          letters.*,
+//          users.email as assigned_responder_email,
+//          users.full_name as assigned_responder_full_name
+//        FROM letters
+//        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
+//        ORDER BY id DESC;
+//     `;
+//     const result = await db.query<LetterQueryResult>(queryText, []);
+//     if (result.rows.length < 1) {
+//       return null;
+//     }
+//     return result.rows.map((r) => queryResultToLetter(r));
+//   } catch (err) {
+//     console.error('Failed to fetch letter by accessKey');
+//     console.error(err);
+//     return null;
+//   }
+// }
 
 // Generate a new letter with random accessKey and accessPassword
 // Returning the original form of both keys

--- a/src/backend/models/letters.ts
+++ b/src/backend/models/letters.ts
@@ -76,9 +76,9 @@ export async function getAssignedLetters(userUuid: string): Promise<Array<Letter
          users.email as assigned_responder_email,
          users.full_name as assigned_responder_full_name,
          replies.status as reply_status,
-         replies.read_receipt,
-         replies.read_timestamp,
-         replies.status_timestamp
+         replies.read_receipt as reply_read_receipt,
+         replies.read_timestamp as reply_read_timestamp,
+         replies.status_timestamp as reply_status_timestamp
        FROM letters
        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
        LEFT OUTER JOIN replies ON letters.uuid = replies.letter_uuid
@@ -108,9 +108,9 @@ export async function getSentLetters(): Promise<Array<Letter> | null> {
          users.email as assigned_responder_email,
          users.full_name as assigned_responder_full_name,
          replies.status as reply_status,
-         replies.read_receipt,
-         replies.read_timestamp,
-         replies.status_timestamp
+         replies.read_receipt as reply_read_receipt,
+         replies.read_timestamp as reply_read_timestamp,
+         replies.status_timestamp as reply_status_timestamp
        FROM letters
        LEFT OUTER JOIN users ON letters.assigned_responder_uuid = users.uuid
        LEFT OUTER JOIN replies ON letters.uuid = replies.letter_uuid

--- a/src/backend/models/replies.ts
+++ b/src/backend/models/replies.ts
@@ -13,6 +13,7 @@ export interface Reply {
   created: string;
   updated: string;
   recipientStatus: RecipientStatus;
+  readTimestamp: Date | null;
 }
 
 export interface ReplyQueryResult {
@@ -26,6 +27,7 @@ export interface ReplyQueryResult {
   content: string;
   content_iv: string;
   recipient_status: RecipientStatus;
+  read_timestamp: Date | null;
 }
 
 function queryResultToReply(row: ReplyQueryResult): Reply {
@@ -40,6 +42,7 @@ function queryResultToReply(row: ReplyQueryResult): Reply {
     authorType: row.author_type,
     internalAuthorUuid: row.internal_author_uuid || null,
     recipientStatus: row.recipient_status,
+    readTimestamp: row.read_timestamp
   };
 }
 
@@ -98,18 +101,20 @@ export async function updateReply({
 export async function updateReplyRecipientStatus({
   uuid,
   recipientStatus,
+  readTimestamp
 }: {
   uuid: string;
   recipientStatus: RecipientStatus;
+  readTimestamp: Date | null;
 }): Promise<Reply | null> {
   try {
     const queryText = `
        UPDATE replies
-       SET recipient_status = $1::text
-       WHERE uuid = $2::text
+       SET recipient_status = $1::text, read_timestamp = $2::timestamp
+       WHERE uuid = $3::text
        RETURNING *;
     `;
-    const queryValues = [recipientStatus, uuid];
+    const queryValues = [recipientStatus, readTimestamp, uuid];
     const result = await db.query<ReplyQueryResult>(queryText, queryValues);
     if (result.rows.length < 1) {
       return null;

--- a/src/backend/models/replies.ts
+++ b/src/backend/models/replies.ts
@@ -1,7 +1,7 @@
 import db from '../db';
 
 import { aesEncrypt, aesDecrypt } from '../utils';
-import { RecipientStatus, ReplyStatus, ResponderType } from '../../common/constants-common';
+import { ReadReceiptStatus, ReplyStatus, ResponderType } from '../../common/constants-common';
 
 export interface Reply {
   uuid: string;
@@ -12,7 +12,7 @@ export interface Reply {
   content: string;
   created: string;
   updated: string;
-  recipientStatus: RecipientStatus;
+  readReceipt: ReadReceiptStatus;
   readTimestamp: Date | null;
 }
 
@@ -26,7 +26,7 @@ export interface ReplyQueryResult {
   internal_author_uuid?: string;
   content: string;
   content_iv: string;
-  recipient_status: RecipientStatus;
+  read_receipt: ReadReceiptStatus;
   read_timestamp: Date | null;
 }
 
@@ -41,7 +41,7 @@ function queryResultToReply(row: ReplyQueryResult): Reply {
     content,
     authorType: row.author_type,
     internalAuthorUuid: row.internal_author_uuid || null,
-    recipientStatus: row.recipient_status,
+    readReceipt: row.read_receipt,
     readTimestamp: row.read_timestamp
   };
 }
@@ -98,30 +98,30 @@ export async function updateReply({
   }
 }
 
-export async function updateReplyRecipientStatus({
+export async function updateReplyReadReceipt({
   uuid,
-  recipientStatus,
+  readReceipt,
   readTimestamp
 }: {
   uuid: string;
-  recipientStatus: RecipientStatus;
+  readReceipt: ReadReceiptStatus;
   readTimestamp: Date | null;
 }): Promise<Reply | null> {
   try {
     const queryText = `
        UPDATE replies
-       SET recipient_status = $1::text, read_timestamp = $2::timestamp
+       SET read_receipt = $1::text, read_timestamp = $2::timestamp
        WHERE uuid = $3::text
        RETURNING *;
     `;
-    const queryValues = [recipientStatus, readTimestamp, uuid];
+    const queryValues = [readReceipt, readTimestamp, uuid];
     const result = await db.query<ReplyQueryResult>(queryText, queryValues);
     if (result.rows.length < 1) {
       return null;
     }
     return queryResultToReply(result.rows[0]);
   } catch (err) {
-    console.error(`Failed update recipient status for reply ${uuid}`);
+    console.error(`Failed update read receipt for reply ${uuid}`);
     console.error(err);
     return null;
   }

--- a/src/backend/routes/letterRoutes.ts
+++ b/src/backend/routes/letterRoutes.ts
@@ -56,7 +56,8 @@ router.get(
           status,
           replyStatus,
           replyReadReceipt,
-          replyReadTimestamp
+          replyReadTimestamp,
+          replyStatusTimestamp
         } = letter;
         return {
           uuid,
@@ -69,7 +70,8 @@ router.get(
           status,
           replyStatus,
           replyReadReceipt,
-          replyReadTimestamp
+          replyReadTimestamp,
+          replyStatusTimestamp
         };
       })
       .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());
@@ -151,6 +153,7 @@ router.post(
       status,
       internalAuthorUuid: user.uuid,
       authorType: ResponderType.internal,
+      statusTimestamp: new Date()
     });
     if (!reply) {
       res.status(400).json({ error: 'Unable to response to letter' });
@@ -193,7 +196,7 @@ router.post(
       return;
     }
     // @ts-ignore
-    const { content, status } = req.body;
+    const { content, status, statusTimestamp } = req.body;
     if (!content || !status) {
       res.status(400).json({ error: 'Missing content or status in request' });
       return;
@@ -202,7 +205,7 @@ router.post(
       res.status(401).json({ error: 'Non staff users are not allowed to publish a response' });
       return;
     }
-    const reply = await updateLettersReply(replyUuid, content, status);
+    const reply = await updateLettersReply(replyUuid, content, status, statusTimestamp);
     if (!reply) {
       res.status(400).json({ error: 'Unable to update reply' });
       return;

--- a/src/backend/routes/letterRoutes.ts
+++ b/src/backend/routes/letterRoutes.ts
@@ -153,7 +153,6 @@ router.post(
       status,
       internalAuthorUuid: user.uuid,
       authorType: ResponderType.internal,
-      statusTimestamp: new Date()
     });
     if (!reply) {
       res.status(400).json({ error: 'Unable to response to letter' });
@@ -196,7 +195,7 @@ router.post(
       return;
     }
     // @ts-ignore
-    const { content, status, statusTimestamp } = req.body;
+    const { content, status } = req.body;
     if (!content || !status) {
       res.status(400).json({ error: 'Missing content or status in request' });
       return;
@@ -205,7 +204,7 @@ router.post(
       res.status(401).json({ error: 'Non staff users are not allowed to publish a response' });
       return;
     }
-    const reply = await updateLettersReply(replyUuid, content, status, statusTimestamp);
+    const reply = await updateLettersReply(replyUuid, content, status);
     if (!reply) {
       res.status(400).json({ error: 'Unable to update reply' });
       return;

--- a/src/backend/routes/letterRoutes.ts
+++ b/src/backend/routes/letterRoutes.ts
@@ -13,10 +13,10 @@ import {
   updateLettersReply,
 } from '../controllers/replyControllers';
 import {
-  ApiLetterAdmin,
   UserRole,
   ResponderType,
   ReplyStatus,
+  ApiLetterWithReadStatus,
 } from '../../common/constants-common';
 import { isAuthenticated } from '../middlewares';
 
@@ -44,7 +44,7 @@ router.get(
     }
 
     const result = letters
-      .map((letter): ApiLetterAdmin => {
+      .map((letter): ApiLetterWithReadStatus => {
         const {
           created,
           uuid,
@@ -55,6 +55,8 @@ router.get(
           assignedResponderFullName,
           status,
           replyStatus,
+          replyReadReceipt,
+          replyReadTimestamp
         } = letter;
         return {
           uuid,
@@ -66,6 +68,8 @@ router.get(
           assignedResponderFullName,
           status,
           replyStatus,
+          replyReadReceipt,
+          replyReadTimestamp
         };
       })
       .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());

--- a/src/backend/routes/onlineLetterRoutes.ts
+++ b/src/backend/routes/onlineLetterRoutes.ts
@@ -1,9 +1,8 @@
 import express from 'express';
-import moment from 'moment';
-import { RecipientStatus } from '../../common/constants-common';
+import { ReadReceiptStatus } from '../../common/constants-common';
 
 import { initiateLetter, sendLetter, readLetter } from '../controllers/letterControllers';
-import { updateLettersReplyRecipientStatus } from '../controllers/replyControllers';
+import { updateLettersReplyReadReceipt } from '../controllers/replyControllers';
 
 const router = express.Router();
 
@@ -51,11 +50,11 @@ router.post('/read', async (req, res) => {
     return;
   }
 
-  // When recipient opens the reply for the first time, it will update its recipient status to "read".
-  if (reply?.recipientStatus === null || reply?.recipientStatus === RecipientStatus.unread) {
-    const success = await updateLettersReplyRecipientStatus(reply.uuid, RecipientStatus.read, new Date());
+  // When recipient opens the reply for the first time, it will update its read receipt to "read".
+  if (reply?.readReceipt === null || reply?.readReceipt === ReadReceiptStatus.unread) {
+    const success = await updateLettersReplyReadReceipt(reply.uuid, ReadReceiptStatus.read, new Date());
     if (!success) {
-      res.status(403).json({ error: 'Cannot update recipient status' });
+      res.status(403).json({ error: 'Cannot update read receipt' });
       return;
     }
   }

--- a/src/backend/routes/onlineLetterRoutes.ts
+++ b/src/backend/routes/onlineLetterRoutes.ts
@@ -64,7 +64,7 @@ router.post('/read', async (req, res) => {
     content: letter.content,
     created: letter.created,
     replyContent: reply ? reply.content : null,
-    replyUpdated: reply ? reply.updated : null,
+    replyUpdated: reply ? reply.statusTimestamp : null, // Status timestamp reflects the time when the content gets updated
   };
   res.status(200).json({ data: letterContent });
 });

--- a/src/backend/routes/onlineLetterRoutes.ts
+++ b/src/backend/routes/onlineLetterRoutes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import moment from 'moment';
 import { RecipientStatus } from '../../common/constants-common';
 
 import { initiateLetter, sendLetter, readLetter } from '../controllers/letterControllers';
@@ -52,7 +53,7 @@ router.post('/read', async (req, res) => {
 
   // When recipient opens the reply for the first time, it will update its recipient status to "read".
   if (reply?.recipientStatus === null || reply?.recipientStatus === RecipientStatus.unread) {
-    const success = await updateLettersReplyRecipientStatus(reply.uuid, RecipientStatus.read);
+    const success = await updateLettersReplyRecipientStatus(reply.uuid, RecipientStatus.read, new Date());
     if (!success) {
       res.status(403).json({ error: 'Cannot update recipient status' });
       return;

--- a/src/backend/routes/onlineLetterRoutes.ts
+++ b/src/backend/routes/onlineLetterRoutes.ts
@@ -51,7 +51,7 @@ router.post('/read', async (req, res) => {
   }
 
   // When recipient opens the reply for the first time, it will update its read receipt to "read".
-  if (reply?.readReceipt === null || reply?.readReceipt === ReadReceiptStatus.unread) {
+  if (reply?.readReceipt === ReadReceiptStatus.unread) {
     const success = await updateLettersReplyReadReceipt(reply.uuid, ReadReceiptStatus.read, new Date());
     if (!success) {
       res.status(403).json({ error: 'Cannot update read receipt' });

--- a/src/backend/routes/onlineLetterRoutes.ts
+++ b/src/backend/routes/onlineLetterRoutes.ts
@@ -1,6 +1,8 @@
 import express from 'express';
+import { RecipientStatus } from '../../common/constants-common';
 
 import { initiateLetter, sendLetter, readLetter } from '../controllers/letterControllers';
+import { updateLettersReplyRecipientStatus } from '../controllers/replyControllers';
 
 const router = express.Router();
 
@@ -47,6 +49,16 @@ router.post('/read', async (req, res) => {
     res.status(403).json({ error: 'Wrong letter access credentials' });
     return;
   }
+
+  // When recipient opens the reply for the first time, it will update its recipient status to "read".
+  if (reply?.recipientStatus === null || reply?.recipientStatus === RecipientStatus.unread) {
+    const success = await updateLettersReplyRecipientStatus(reply.uuid, RecipientStatus.read);
+    if (!success) {
+      res.status(403).json({ error: 'Cannot update recipient status' });
+      return;
+    }
+  }
+
   const letterContent = {
     title: letter.title,
     content: letter.content,

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -71,7 +71,7 @@ export enum ReplyStatus {
   published = 'published',
 }
 
-export enum RecipientStatus {
+export enum ReadReceiptStatus {
   unread = 'unread',
   read = 'read',
 }
@@ -91,7 +91,7 @@ export interface ApiReplyAdmin {
   content: string;
   created: string;
   updated: string;
-  recipientStatus: RecipientStatus;
+  readReceipt: ReadReceiptStatus;
   readTimestamp: string | null;
 }
 

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -46,6 +46,11 @@ export interface ApiLetterAdmin {
   replyStatusTimestamp: string | null;
 }
 
+export interface ApiLetterWithRespoder extends ApiLetterAdmin {
+  replyReadReceipt: ReadReceiptStatus | null;
+  replyReadTimestamp: string | null;
+}
+
 export interface ApiLetterContent {
   title: string;
   content: string;

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -92,6 +92,7 @@ export interface ApiReplyAdmin {
   created: string;
   updated: string;
   recipientStatus: RecipientStatus;
+  readTimestamp: string | null;
 }
 
 export const weekDays = [

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -71,6 +71,11 @@ export enum ReplyStatus {
   published = 'published',
 }
 
+export enum RecipientStatus {
+  unread = 'unread',
+  read = 'read',
+}
+
 export interface ApiReplyParamsAdmin {
   letterUuid: string;
   content: string;
@@ -86,6 +91,7 @@ export interface ApiReplyAdmin {
   content: string;
   created: string;
   updated: string;
+  recipientStatus: RecipientStatus;
 }
 
 export const weekDays = [

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -43,6 +43,7 @@ export interface ApiLetterAdmin {
   assignedResponderUuid: string | null;
   assignedResponderEmail: string | null;
   assignedResponderFullName: string | null;
+  replyStatusTimestamp: string | null;
 }
 
 export interface ApiLetterContent {
@@ -93,6 +94,7 @@ export interface ApiReplyAdmin {
   updated: string;
   readReceipt: ReadReceiptStatus;
   readTimestamp: string | null;
+  statusTimestamp: string | null;
 }
 
 export interface ApiLetterWithReadStatus extends ApiLetterAdmin {

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -95,6 +95,11 @@ export interface ApiReplyAdmin {
   readTimestamp: string | null;
 }
 
+export interface ApiLetterWithReadStatus extends ApiLetterAdmin {
+  replyReadReceipt: ReadReceiptStatus | null;
+  replyReadTimestamp: string | null;
+}
+
 export const weekDays = [
   'sunday',
   'monday',

--- a/src/frontend/Letters.tsx
+++ b/src/frontend/Letters.tsx
@@ -3,7 +3,12 @@ import { RouteComponentProps, Link } from '@reach/router';
 import styled from 'styled-components';
 import Select from 'react-select';
 
-import { ApiLetterAdmin, ApiUserData, UserRole } from '../common/constants-common';
+import {
+  ApiLetterAdmin,
+  ApiLetterWithReadStatus,
+  ApiUserData,
+  UserRole,
+} from '../common/constants-common';
 import { useNotifications } from './NotificationsContext';
 import { useAuth } from './AuthContext';
 import { useRequest } from './http';
@@ -20,7 +25,7 @@ const LettersTable = styled.table`
 `;
 
 export const Letters: React.FunctionComponent<RouteComponentProps> = () => {
-  const [letters, setLetters] = useState<Array<ApiLetterAdmin>>([]);
+  const [letters, setLetters] = useState<Array<ApiLetterWithReadStatus>>([]);
   const [users, setUsers] = useState<Array<ApiUserData>>([]);
   const { addNotification } = useNotifications();
   const { getRequest, postRequest } = useRequest();
@@ -42,7 +47,7 @@ export const Letters: React.FunctionComponent<RouteComponentProps> = () => {
 
   const fetchLetters = useCallback(async () => {
     try {
-      const result = await getRequest<{ data: Array<ApiLetterAdmin> }>(`/api/letters`, {
+      const result = await getRequest<{ data: Array<ApiLetterWithReadStatus> }>(`/api/letters`, {
         useJwt: true,
       });
       setLetters(
@@ -123,6 +128,7 @@ export const Letters: React.FunctionComponent<RouteComponentProps> = () => {
             <th>Created</th>
             <th>Title</th>
             <th>Reply status</th>
+            <th>Read receipt</th>
             {isStaff && <th>Assigned to</th>}
           </tr>
         </thead>
@@ -135,6 +141,11 @@ export const Letters: React.FunctionComponent<RouteComponentProps> = () => {
                   <Link to={letter.uuid}>{letter.title}</Link>
                 </td>
                 <td>{letter.replyStatus || ''}</td>
+                <th>
+                  {letter.replyReadTimestamp
+                    ? moment(letter.replyReadTimestamp).format('dddd DD/MM/YYYY, HH:mm')
+                    : '-'}
+                </th>
                 {isStaff && (
                   <td style={{ maxWidth: 200 }}>
                     <OverrideTurretInputHeightForReactSelectDiv>

--- a/src/frontend/Letters.tsx
+++ b/src/frontend/Letters.tsx
@@ -141,11 +141,11 @@ export const Letters: React.FunctionComponent<RouteComponentProps> = () => {
                   <Link to={letter.uuid}>{letter.title}</Link>
                 </td>
                 <td>{letter.replyStatus || ''}</td>
-                <th>
+                <td>
                   {letter.replyReadTimestamp
                     ? moment(letter.replyReadTimestamp).format('dddd DD/MM/YYYY, HH:mm')
                     : '-'}
-                </th>
+                </td>
                 {isStaff && (
                   <td style={{ maxWidth: 200 }}>
                     <OverrideTurretInputHeightForReactSelectDiv>

--- a/src/frontend/Reply.tsx
+++ b/src/frontend/Reply.tsx
@@ -160,15 +160,19 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
       {reply && (
         <p>
           <i>
-            <b>Updated on:</b> {reply.updated ? moment(reply.updated).format('dddd DD/MM/YYYY, HH:mm') : 'never'}
+            <b>Updated on:</b>{' '}
+            {reply.updated ? moment(reply.updated).format('dddd DD/MM/YYYY, HH:mm') : 'never'}
           </i>
           <br />
           <i>
             <b>Status:</b> {reply.status}
           </i>
+          <br />
+          <i>
+            <b>Read on:</b> {reply?.readTimestamp ? moment(reply?.readTimestamp).format('ddd Do MMM YYYY HH:mm') : "-"}
+          </i>
         </p>
       )}
-
       {disableReplyEdit ? replyContent : editForm}
     </>
   );

--- a/src/frontend/Reply.tsx
+++ b/src/frontend/Reply.tsx
@@ -169,7 +169,7 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
           </i>
           <br />
           <i>
-            <b>Read on:</b> {reply?.readTimestamp ? moment(reply?.readTimestamp).format('ddd Do MMM YYYY HH:mm') : "-"}
+            <b>Read on:</b> {reply?.readTimestamp ? moment(reply?.readTimestamp).format('dddd DD/MM/YYYY, HH:mm') : "-"}
           </i>
         </p>
       )}

--- a/src/frontend/Reply.tsx
+++ b/src/frontend/Reply.tsx
@@ -32,7 +32,12 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
         if (!reply) {
           const result = await postRequest<{ data: ApiReplyAdmin }>(
             `/api/letters/${letter.uuid}/reply`,
-            { letterUuid: letter.uuid, content: replyContent.value, status },
+            {
+              letterUuid: letter.uuid,
+              content: replyContent.value,
+              status,
+              statusTimestamp: new Date(),
+            },
             { useJwt: true },
           );
           setReply(result.data.data);
@@ -46,6 +51,7 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
               status,
               letterUuid: letter.uuid,
               content: replyContent.value,
+              statusTimestamp: new Date(),
             },
             { useJwt: true },
           );
@@ -161,7 +167,9 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
         <p>
           <i>
             <b>Updated on:</b>{' '}
-            {reply.updated ? moment(reply.updated).format('dddd DD/MM/YYYY, HH:mm') : 'never'}
+            {reply.statusTimestamp
+              ? moment(reply.statusTimestamp).format('dddd DD/MM/YYYY, HH:mm')
+              : 'never'}
           </i>
           <br />
           <i>
@@ -169,7 +177,10 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
           </i>
           <br />
           <i>
-            <b>Read on:</b> {reply?.readTimestamp ? moment(reply?.readTimestamp).format('dddd DD/MM/YYYY, HH:mm') : "-"}
+            <b>Read on:</b>{' '}
+            {reply?.readTimestamp
+              ? moment(reply?.readTimestamp).format('dddd DD/MM/YYYY, HH:mm')
+              : '-'}
           </i>
         </p>
       )}

--- a/src/frontend/Reply.tsx
+++ b/src/frontend/Reply.tsx
@@ -36,7 +36,6 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
               letterUuid: letter.uuid,
               content: replyContent.value,
               status,
-              statusTimestamp: new Date(),
             },
             { useJwt: true },
           );
@@ -51,7 +50,6 @@ export const Reply: React.FunctionComponent<RouteComponentProps<{ letterUuid: st
               status,
               letterUuid: letter.uuid,
               content: replyContent.value,
-              statusTimestamp: new Date(),
             },
             { useJwt: true },
           );


### PR DESCRIPTION
**Summaries:**
- Add `read_receipt` and `read_timestamp` to track when the reply has been opened for the first time
- Add `status_timestamp` to track when the reply status/content has been modified
- Add **Read receipt** column on the _Letters_ page
- Add **Read on** field on the _Reply_ page to show the time when the reply's opened