### PR TITLE
Config for how many days before booking to send reminder

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -33,6 +33,13 @@ export SENDGRID_VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID=
 # In production this should be a single number to avoid sending same email multiple times a day.
 export BOOKING_REMINDER_SENDING_HOUR=9
 
+# How many days before the day the booking starts we send the reminder email?
+# If set to zero, reminders will be sent at "BOOKING_REMINDER_SENDING_HOUR" on
+# the exact day when the booking starts, if set to 1 the day before that etc.
+# Unset/comment this to disable the reminders.
+export BOOKING_REMINDER_DAYS_BEFORE=3
+
+
 # The list of allowed CORS origins requests to the backend API.
 # If more than one origins are allowed, they can can separated by a "," - without any space in between.
 # For example: http://domain1.com,http://domain2.com

--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -208,14 +208,23 @@ export function createApp() {
 function activateNotificationCronJobs() {
   // Send booking notifications to volunteers
   // some days before the booking they had made.
-  const hour = getConfig().bookingReminderSendingHour
+  const hour = getConfig().bookingReminderSendingHour;
+  const daysBeforeString = getConfig().bookingReminderDaysBefore;
   if (!hour) {
-    console.log("Env BOOKING_REMINDER_SENDING_HOUR was not set, not sending any booking reminders")
+    console.warn("Env BOOKING_REMINDER_SENDING_HOUR was not set, not sending any booking reminders");
     return;
+  }
+  if (!daysBeforeString) {
+    console.warn("Env BOOKING_REMINDER_DAYS_BEFORE was not set, not sending any booking reminders");
+    return;
+  }
+  const daysBefore = parseInt(daysBeforeString, 10);
+  if (isNaN(daysBefore)) {
+    console.warn(`Env BOOKING_REMINDER_DAYS_BEFORE was set to an invalid value "${daysBefore}", not a single number`);
   }
 
   cron.schedule(`0 ${hour} * * *`, async () => {
-    const results = await sendBookingRemindersToVolunteers();
+    const results = await sendBookingRemindersToVolunteers(daysBefore);
 
     if (typeof results === 'undefined') {
       console.log("Failed to run sendBookingRemindersToVolunteers");

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -51,6 +51,9 @@ export function getConfig() {
   if (process.env.ENVIRONMENT === 'production' && !process.env.BOOKING_REMINDER_SENDING_HOUR) {
     throw 'Variable BOOKING_REMINDER_SENDING_HOUR is missing from your environment';
   }
+  if (process.env.ENVIRONMENT === 'production' && !process.env.BOOKING_REMINDER_DAYS_BEFORE) {
+    throw 'Variable BOOKING_REMINDER_DAYS_BEFORE is missing from your environment';
+  }
 
   // `checkVariables` should ensure required variables are available here. Unfortunately typescript
   // is not able to pick this up automatically. So disabling no-non-null-assertion eslint rule here.
@@ -94,5 +97,6 @@ export function getConfig() {
     sendGridVolunteerBookingConfirmationTemplate: process.env.SENDGRID_VOLUNTEER_BOOKING_CONFIRMATION_TEMPLATE_ID || null,
     sendGridVolunteerBookingReminderTemplate: process.env.SENDGRID_VOLUNTEER_BOOKING_REMINDER_TEMPLATE_ID || null,
     bookingReminderSendingHour: process.env.BOOKING_REMINDER_SENDING_HOUR || null,
+    bookingReminderDaysBefore: process.env.BOOKING_REMINDER_DAYS_BEFORE || null,
   };
 }

--- a/src/backend/controllers/emailControllers.ts
+++ b/src/backend/controllers/emailControllers.ts
@@ -86,7 +86,7 @@ export async function sendBookingConfirmationEmail(booking: ApiBooking) {
  * If same volunteer has multiple bookings for the same day, they will
  * get multiple notifications sent at the same time.
  */
-export async function sendBookingRemindersToVolunteers(): Promise<boolean[] | undefined> {
+export async function sendBookingRemindersToVolunteers(bookingReminderDaysBefore: number): Promise<boolean[] | undefined> {
   const { sendGridFromEmailAddress, sendGridVolunteerBookingReminderTemplate } = getConfig();
   if (!sendGridFromEmailAddress) {
     console.log('No From email adress was set');
@@ -108,9 +108,6 @@ export async function sendBookingRemindersToVolunteers(): Promise<boolean[] | un
   // Find which bookings we want to send a reminder for
   const bookingsToRemindAbout = bookings
     .filter(booking => {
-      const bookingReminderDaysBefore: number | null = 3; // remind 3 days before booking
-      if (bookingReminderDaysBefore === null) return false; // user does not want a reminder
-
       const slotDay = new Date(booking.start);
       const today = new Date();
 


### PR DESCRIPTION
Adds a new environment variable to control how many days before the day of the booking we need to send reminders to the volunteer who made the booking. Notifications are also sent to staff members if they made the booking and left their email address to the email field.

The environment variable `BOOKING_REMINDER_DAYS_BEFORE` is mandatory in production, and it has been already set for prod and dev environments in Heroku to default value of 3.

Closes #82.