### PR TITLE
Color for booking type tag under bookings table

### DIFF
--- a/src/backend/controllers/bookingControllers.ts
+++ b/src/backend/controllers/bookingControllers.ts
@@ -1,10 +1,10 @@
-import { ApiBooking, ApiBookingType, ApiBookingUserStats } from '../../common/constants-common';
+import { ApiBooking, ApiBookingType, ApiBookingUserStats, ApiBookingWithColor } from '../../common/constants-common';
 
 import * as bookingTypesController from './bookingTypeControllers';
 import * as bookingsModel from '../models/bookings';
 import * as usersModel from '../models/users';
 
-export async function getUserBookings(userUuid: string): Promise<Array<ApiBooking> | null> {
+export async function getUserBookings(userUuid: string): Promise<Array<ApiBookingWithColor> | null> {
   const user = await usersModel.getUserByUuid(userUuid);
   if (!user) {
     console.log(`User ${userUuid} not found`);
@@ -40,10 +40,10 @@ export async function getUserBookings(userUuid: string): Promise<Array<ApiBookin
         bookingType: bookingTypes.find(({ uuid }) => uuid === bookingTypeUuid) || null,
       }),
     )
-    .filter(({ bookingType }) => !!bookingType) as Array<ApiBooking>;
+    .filter(({ bookingType }) => !!bookingType) as Array<ApiBookingWithColor>;
 }
 
-export async function getAllBookings(): Promise<Array<ApiBooking> | null> {
+export async function getAllBookings(): Promise<Array<ApiBookingWithColor> | null> {
   const users = await usersModel.getUsers();
   const bookings = await bookingsModel.getAllBookings();
   if (bookings === null || users === null) {
@@ -76,7 +76,7 @@ export async function getAllBookings(): Promise<Array<ApiBooking> | null> {
         bookingType: bookingTypes.find(({ uuid }) => uuid === bookingTypeUuid) || null,
       }),
     )
-    .filter(({ user }) => !!user) as Array<ApiBooking>;
+    .filter(({ user }) => !!user) as Array<ApiBookingWithColor>;
 }
 
 export async function createBooking(

--- a/src/backend/controllers/bookingTypeControllers.ts
+++ b/src/backend/controllers/bookingTypeControllers.ts
@@ -44,7 +44,7 @@ export async function getBookingTypes(): Promise<Array<ApiBookingTypeWithColor> 
           exceptions: b.exceptions,
           dateRanges: b.dateRanges,
           additionalInformation: b.additionalInformation,
-          color: BookingTypeColors[index % Object.keys(BookingTypeColors).length],
+          color: BookingTypeColors[index % BookingTypeColors.length],
         }))
     : null;
 }

--- a/src/backend/controllers/bookingTypeControllers.ts
+++ b/src/backend/controllers/bookingTypeControllers.ts
@@ -33,7 +33,7 @@ export async function getBookingTypes(): Promise<Array<ApiBookingTypeWithColor> 
   const allBookingTypes = await model.getAllBookingTypes();
   return allBookingTypes !== null
     ? allBookingTypes
-        .sort((a, b) => (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1))
+        .sort((a, b) => new Date(a.created).getTime() - new Date(b.created).getTime())
         .map((b, index) => ({
           uuid: b.uuid,
           name: b.name,

--- a/src/backend/controllers/bookingTypeControllers.ts
+++ b/src/backend/controllers/bookingTypeControllers.ts
@@ -1,6 +1,10 @@
 import * as model from '../models/bookingTypes';
 
-import { ApiBookingType } from '../../common/constants-common';
+import {
+  ApiBookingType,
+  ApiBookingTypeWithColor,
+  BookingTypeColors,
+} from '../../common/constants-common';
 
 export async function addBookingType({
   name,
@@ -25,28 +29,43 @@ export async function addBookingType({
     : null;
 }
 
-export async function getBookingTypes(): Promise<Array<ApiBookingType> | null> {
+export async function getBookingTypes(): Promise<Array<ApiBookingTypeWithColor> | null> {
   const allBookingTypes = await model.getAllBookingTypes();
   return allBookingTypes !== null
-    ? allBookingTypes.map((b) => ({
-        uuid: b.uuid,
-        name: b.name,
-        rules: b.rules,
-        exceptions: b.exceptions,
-        additionalInformation: b.additionalInformation,
-      }))
+    ? allBookingTypes
+        .sort((a, b) => (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1))
+        .map((b, index) => ({
+          uuid: b.uuid,
+          name: b.name,
+          rules: b.rules,
+          exceptions: b.exceptions,
+          additionalInformation: b.additionalInformation,
+          color: BookingTypeColors[index % Object.keys(BookingTypeColors).length],
+        }))
     : null;
 }
 
 export async function getBookingTypeByUuid(
   bookingTypeUuid: string,
-): Promise<ApiBookingType | null> {
-  const bookingType = await model.getBookingTypeByUuid(bookingTypeUuid);
-  if (bookingType === null) {
+): Promise<ApiBookingTypeWithColor | null> {
+  // const bookingType = await model.getBookingTypeByUuid(bookingTypeUuid);
+  // if (bookingType === null) {
+  //   return null;
+  // }
+  // const { uuid, name, rules, exceptions, additionalInformation } = bookingType;
+  // return {
+  //   uuid,
+  //   name,
+  //   rules,
+  //   exceptions,
+  //   additionalInformation,
+  // };
+  const bookingTypes = await getBookingTypes();
+  if (bookingTypes === null) {
     return null;
   }
-  const { uuid, name, rules, exceptions, additionalInformation } = bookingType;
-  return { uuid, name, rules, exceptions, additionalInformation };
+  const result = bookingTypes.find((b) => b.uuid === bookingTypeUuid) || null;
+  return result;
 }
 
 export async function updateBookingType({

--- a/src/backend/routes/bookingRoutes.ts
+++ b/src/backend/routes/bookingRoutes.ts
@@ -15,6 +15,7 @@ import {
   ApiUpdateBookingParams,
   ApiBookedSlot,
   ApiBookingUserStats,
+  ApiBookingWithColor,
 } from '../../common/constants-common';
 import {
   sendBookingConfirmationEmail,
@@ -113,7 +114,7 @@ router.get<Record<string, never>, { data: Array<ApiBooking> } | { error: string 
   },
 );
 
-router.get<Record<string, never>, { data: Array<ApiBooking> } | { error: string }>(
+router.get<Record<string, never>, { data: Array<ApiBookingWithColor> } | { error: string }>(
   '/all',
   // Only allow staff to view all detailed booking information
   isAuthenticated([UserRole.staff]),

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -225,11 +225,11 @@ export interface ApiUpdateUserSettingsParams {
 
 export type ApiUpdatePageParams = Omit<ApiPage, 'uuid'>;
 
-export enum BookingTypeColors {
+export const BookingTypeColors = [
   'rgba(192, 46, 29, 0.9)',
   'rgba(13, 84, 73, 0.9)',
   'rgba(13, 60, 85, 0.9)',
   'rgba(84, 38, 13, 0.9)',
   'rgba(81, 84, 10, 0.9)',
   'rgba(34, 34, 51, 0.9)',
-}
+];

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -146,6 +146,10 @@ export interface ApiBookingType {
   additionalInformation: string | null;
 }
 
+export interface ApiBookingTypeWithColor extends ApiBookingType {
+  color: string;
+}
+
 export interface ApiBookingTypeParamsAdmin {
   name: string;
   rules: BookingTypeDailyRules;
@@ -165,19 +169,25 @@ export interface ApiCreateBookingParams {
   workingRemotely: boolean;
 }
 
-export interface ApiBooking {
+export interface ApiBookingBase {
   uuid: string;
   email: string;
   phone: string;
   fullName: string;
   user: ApiUserData;
-  bookingType: ApiBookingType;
   bookingNote: string;
   workingRemotely: boolean;
   // These are stored separatedly in order to retain past booking information in cased the bookingType is deleted,
   // or slot timing changed.
   start: string;
   end: string;
+}
+export interface ApiBooking extends ApiBookingBase {
+  bookingType: ApiBookingType;
+}
+
+export interface ApiBookingWithColor extends ApiBookingBase {
+  bookingType: ApiBookingTypeWithColor;
 }
 
 export interface ApiUpdateBookingParams {

--- a/src/common/constants-common.ts
+++ b/src/common/constants-common.ts
@@ -214,3 +214,12 @@ export interface ApiUpdateUserSettingsParams {
 }
 
 export type ApiUpdatePageParams = Omit<ApiPage, 'uuid'>;
+
+export enum BookingTypeColors {
+  'rgba(192, 46, 29, 0.9)',
+  'rgba(13, 84, 73, 0.9)',
+  'rgba(13, 60, 85, 0.9)',
+  'rgba(84, 38, 13, 0.9)',
+  'rgba(81, 84, 10, 0.9)',
+  'rgba(34, 34, 51, 0.9)',
+}

--- a/src/frontend/BookingCalendar/BookingCalendar.tsx
+++ b/src/frontend/BookingCalendar/BookingCalendar.tsx
@@ -7,7 +7,7 @@ import {
 } from '@reach/dialog';
 import '@reach/dialog/styles.css';
 
-import { ApiBookingType, ApiBookedSlot, ApiBooking } from '../../common/constants-common';
+import { ApiBookingType, ApiBookedSlot, ApiBooking, BookingTypeColors } from '../../common/constants-common';
 import { useRequest } from '../http';
 import { useNotifications } from '../NotificationsContext';
 import { CalendarColumn } from './CalendarColumn';
@@ -28,15 +28,6 @@ const DialogContent = styled(ReachDialogContent)`
 type BookingCalendarProps = {
   bookingTypes: Array<ApiBookingType>;
 };
-
-const bookingTypeColors = [
-  'rgba(192, 46, 29, 0.9)',
-  'rgba(13, 84, 73, 0.9)',
-  'rgba(13, 60, 85, 0.9)',
-  'rgba(84, 38, 13, 0.9)',
-  'rgba(81, 84, 10, 0.9)',
-  'rgba(34, 34, 51, 0.9)',
-];
 
 export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }) => {
   // Give current date in Finnish (since default timezone was already set in App.tsx)
@@ -123,8 +114,8 @@ export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }
 
   const getBookingTypeColor = useCallback(
     (id) => {
-      return bookingTypeColors[
-        bookingTypes.findIndex(({ uuid }) => uuid === id) % bookingTypeColors.length
+      return BookingTypeColors[
+        bookingTypes.findIndex(({ uuid }) => uuid === id) % Object.keys(BookingTypeColors).length
       ];
     },
     [bookingTypes],

--- a/src/frontend/BookingCalendar/BookingCalendar.tsx
+++ b/src/frontend/BookingCalendar/BookingCalendar.tsx
@@ -7,7 +7,7 @@ import {
 } from '@reach/dialog';
 import '@reach/dialog/styles.css';
 
-import { ApiBookingType, ApiBookedSlot, ApiBooking, BookingTypeColors } from '../../common/constants-common';
+import { ApiBookedSlot, ApiBooking, ApiBookingTypeWithColor } from '../../common/constants-common';
 import { useRequest } from '../http';
 import { useNotifications } from '../NotificationsContext';
 import { CalendarColumn } from './CalendarColumn';
@@ -26,7 +26,7 @@ const DialogContent = styled(ReachDialogContent)`
 `;
 
 type BookingCalendarProps = {
-  bookingTypes: Array<ApiBookingType>;
+  bookingTypes: Array<ApiBookingTypeWithColor>;
 };
 
 export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }) => {
@@ -112,15 +112,6 @@ export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }
     startDate.clone().add(dayOffset, 'days'),
   );
 
-  const getBookingTypeColor = useCallback(
-    (id) => {
-      return BookingTypeColors[
-        bookingTypes.findIndex(({ uuid }) => uuid === id) % Object.keys(BookingTypeColors).length
-      ];
-    },
-    [bookingTypes],
-  );
-
   const openBookingForm = (details: BookingSlotDetails) => {
     setBookingDetails(details);
   };
@@ -141,7 +132,7 @@ export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }
         style={{ width: '12rem', top: 0, marginRight: '3rem' }}
       >
         <h1 className="font-size-xxl">Book a slot</h1>
-        {bookingTypes.map(({ uuid, name }) => (
+        {bookingTypes.map(({ uuid, name, color }) => (
           <div key={uuid} className="flex align-items-center margin-vertical-1-4">
             <div
               aria-hidden={true}
@@ -151,7 +142,7 @@ export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }
                 borderRadius: '50%',
                 marginRight: 8,
                 flexShrink: 0,
-                background: getBookingTypeColor(uuid),
+                background: color,
               }}
             />
             <input
@@ -191,7 +182,7 @@ export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }
             });
 
             const slotsInCurrentDay = bookingTypesInCurrentDay.flatMap(
-              ({ rules, uuid, name, additionalInformation }) =>
+              ({ rules, uuid, name, additionalInformation, color }) =>
                 rules[currentDate.weekday()].slots.map(({ start, end, seats }) => {
                   const [startHour, startMinute] = start.split(':');
                   const [endHour, endMinute] = end.split(':');
@@ -199,7 +190,7 @@ export const BookingCalendar: React.FC<BookingCalendarProps> = ({ bookingTypes }
                     seats,
                     bookingTypeUuid: uuid,
                     bookingTypeName: name,
-                    bookingTypeColor: getBookingTypeColor(uuid),
+                    bookingTypeColor: color,
                     bookingTypeAdditionalInformation: additionalInformation || '',
                     start: currentDate
                       .clone()

--- a/src/frontend/Profile.tsx
+++ b/src/frontend/Profile.tsx
@@ -1,22 +1,54 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, Link } from '@reach/router';
 import DataTable from 'react-data-table-component';
 
 import { useRequest } from './http';
-import { ApiBooking, ApiUserData, TokenUserData, UserRole } from '../common/constants-common';
+import {
+  ApiBooking,
+  ApiBookingType,
+  ApiUserData,
+  BookingTypeColors,
+  TokenUserData,
+  UserRole,
+} from '../common/constants-common';
 import moment from 'moment';
 import { useAuth } from './AuthContext';
+import { useNotifications } from './NotificationsContext';
 
 export const Profile: React.FunctionComponent<RouteComponentProps<{ userUuid: string }>> = ({
   userUuid,
 }) => {
   const { user: loggedInUser } = useAuth();
 
+  const [bookingTypes, setBookingTypes] = useState<Array<ApiBookingType>>([]);
   const [bookings, setBookings] = useState<Array<ApiBooking>>([]);
   const [user, setUser] = useState<ApiUserData>();
-  const { getRequest } = useRequest();
   const upcomingBookings = bookings.filter(({ end }) => new Date() < new Date(end));
   const pastBookings = bookings.filter(({ end }) => new Date() >= new Date(end));
+
+  const { getRequest } = useRequest();
+  const { addNotification } = useNotifications();
+
+  const fetchBookingTypes = useCallback(async () => {
+    try {
+      const bookingTypesResult = await getRequest<{ data: Array<ApiBookingType> }>(
+        '/api/booking-types',
+        { useJwt: true },
+      );
+      setBookingTypes(
+        bookingTypesResult.data.data.sort((a, b) =>
+          a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1,
+        ),
+      );
+    } catch (err) {
+      console.log(err);
+      addNotification({ type: 'error', message: 'Unable to get all booking types' });
+    }
+  }, [addNotification, setBookingTypes, getRequest]);
+
+  useEffect(() => {
+    fetchBookingTypes();
+  }, [fetchBookingTypes]);
 
   useEffect(() => {
     let updateStateAfterFetch = true;
@@ -65,13 +97,13 @@ export const Profile: React.FunctionComponent<RouteComponentProps<{ userUuid: st
           <p>
             <b>Please note booking times are in Europe/Helsinki timezone</b>
           </p>
-          <BookingList bookings={upcomingBookings} />
+          <BookingList bookingTypes={bookingTypes} bookings={upcomingBookings} />
         </>
       )}
       {pastBookings.length > 0 && (
         <>
           <h1>Past bookings</h1>
-          <BookingList bookings={pastBookings} defaultSortAsc={false} />
+          <BookingList bookingTypes={bookingTypes} bookings={pastBookings} defaultSortAsc={false} />
         </>
       )}
     </div>
@@ -106,19 +138,37 @@ const UserProfile: React.FC<{ loggedInUser: TokenUserData | null; user: ApiUserD
   );
 };
 
-const BookingList: React.FC<{ bookings: Array<ApiBooking>; defaultSortAsc?: boolean }> = ({
-  bookings,
-  defaultSortAsc,
-}) => {
+const BookingList: React.FC<{
+  bookingTypes: Array<ApiBookingType>;
+  bookings: Array<ApiBooking>;
+  defaultSortAsc?: boolean;
+}> = ({ bookingTypes, bookings, defaultSortAsc }) => {
   const dateSort = (a: { start: string }, b: { start: string }) => {
     return new Date(a.start) > new Date(b.start) ? 1 : -1;
   };
 
+  const getBookingTypeColor = useCallback(
+    (id) => {
+      return BookingTypeColors[
+        bookingTypes.findIndex(({ uuid }) => uuid === id) % Object.keys(BookingTypeColors).length
+      ];
+    },
+    [bookingTypes],
+  );
+
   const columns = [
     {
       id: 1,
-      name: 'Title',
+      name: 'Type',
       selector: (row: ApiBooking) => row.bookingType.name,
+      format: (row: ApiBooking) => (
+        <div
+          className="padding-xxs border-radius color-white font-weight-bold"
+          style={{ background: getBookingTypeColor(row.bookingType.uuid) }}
+        >
+          {row.bookingType.name}
+        </div>
+      ),
       wrap: true,
     },
     {

--- a/src/frontend/pages/Booking.tsx
+++ b/src/frontend/pages/Booking.tsx
@@ -1,27 +1,23 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { RouteComponentProps } from '@reach/router';
 
-import { ApiBookingType } from '../../common/constants-common';
+import { ApiBookingTypeWithColor } from '../../common/constants-common';
 import { useRequest } from '../http';
 import { useNotifications } from '../NotificationsContext';
 import { BookingCalendar } from '../BookingCalendar/BookingCalendar';
 
 export const Booking: React.FunctionComponent<RouteComponentProps> = () => {
-  const [bookingTypes, setBookingTypes] = useState<Array<ApiBookingType>>([]);
+  const [bookingTypes, setBookingTypes] = useState<Array<ApiBookingTypeWithColor>>([]);
   const { getRequest } = useRequest();
   const { addNotification } = useNotifications();
 
   const fetchBookingTypes = useCallback(async () => {
     try {
-      const bookingTypesResult = await getRequest<{ data: Array<ApiBookingType> }>(
+      const bookingTypesResult = await getRequest<{ data: Array<ApiBookingTypeWithColor> }>(
         '/api/booking-types',
         { useJwt: true },
       );
-      setBookingTypes(
-        bookingTypesResult.data.data.sort((a, b) =>
-          a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1,
-        ),
-      );
+      setBookingTypes(bookingTypesResult.data.data);
     } catch (err) {
       console.log(err);
       addNotification({ type: 'error', message: 'Unable to get all booking types' });
@@ -35,7 +31,7 @@ export const Booking: React.FunctionComponent<RouteComponentProps> = () => {
   return <BookingCalendar bookingTypes={bookingTypes} />;
 };
 
-export function isBookableDay(date: Date, bookingType: ApiBookingType): boolean {
+export function isBookableDay(date: Date, bookingType: ApiBookingTypeWithColor): boolean {
   const weekDay = date.getDay();
   return weekDay === undefined
     ? false


### PR DESCRIPTION
**Summaries:**
- Move the logic for assigning a color to a booking type to `bookingTypeControllers.ts` when the booking types are fetched
- The index used in the color assignment is now based on its position after it's sorted by creation date (not alphanumeric order)
- Move the colors constant to the `common/constants-common.ts`
- Add `ApiBookingWithColor` interface that includes the color
- Add color to the booking types under _all bookings_ and _individual user page (profile)_ page