### PR TITLE
Add moment locale data

### DIFF
--- a/src/frontend/Navigation.tsx
+++ b/src/frontend/Navigation.tsx
@@ -2,6 +2,9 @@ import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Link } from '@reach/router';
 import Select from 'react-select';
+import moment from 'moment-timezone';
+import 'moment/locale/fi';
+import 'moment/locale/en-gb';
 
 // Use translation
 import { useTranslation } from 'react-i18next';
@@ -65,6 +68,8 @@ const MainMenu: React.FC<{ afterMenuClicked: () => void }> = ({ afterMenuClicked
 
   const handleLanguageChanged = (selected: OptionType) => {
     setLanguage(selected.value);
+    const momentLocale = selected.value === 'fi' ? 'fi' : 'en-gb';
+    moment.locale(momentLocale);
     i18n.changeLanguage(selected.value);
   };
 


### PR DESCRIPTION
- Load moment locale data that defines date related calculation logics (like first day of week, first day of January that's considered the first week of the year, etc...). This should fix the issue with our week number in the booking calendar being 1 higher than the ISO convention that is used in Finland.