### PR TITLE
Avoid slot button overlapping other bookings after focused

### DIFF
--- a/src/frontend/pages/Booking/BookingCalendar/CalendarColumn.tsx
+++ b/src/frontend/pages/Booking/BookingCalendar/CalendarColumn.tsx
@@ -191,8 +191,8 @@ const SlotButton = styled.button<{
     z-index: inherit !important;
     &:hover {
       z-index: 2 !important;
-    };
-  };
+    }
+  }
   ${({ background, leftOffset, top, height, width }) => css`
     top: ${top};
     height: ${height};

--- a/src/frontend/pages/Booking/BookingCalendar/CalendarColumn.tsx
+++ b/src/frontend/pages/Booking/BookingCalendar/CalendarColumn.tsx
@@ -187,6 +187,12 @@ const SlotButton = styled.button<{
   position: absolute;
   text-align: left;
   font-size: 0.8rem;
+  &:focus {
+    z-index: inherit !important;
+    &:hover {
+      z-index: 2 !important;
+    };
+  };
   ${({ background, leftOffset, top, height, width }) => css`
     top: ${top};
     height: ${height};


### PR DESCRIPTION
Use default z-index for slot button `:focus` state, to avoid a slot covering an overlapping one after a booking is made.